### PR TITLE
Change how we print installed Elixir version

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4780,13 +4780,14 @@ async function getElixirVersion(exSpec0, otpVersion) {
     if (elixirVersions.get(elixirVersion).includes(otpMatch[1])) {
       // ... and it's available: use it!
       elixirVersionWithOTP = `${elixirVersion}-otp-${otpVersionMajor}`
-      core.info(`Using Elixir ${elixirVersion} (built for OTP ${otpVersionMajor})`)
+      core.info(
+        `Using Elixir ${elixirVersion} (built for OTP ${otpVersionMajor})`,
+      )
     } else {
       // ... and it's not available: fallback to the "generic" version (v1.4.5 only).
       elixirVersionWithOTP = elixirVersion
       core.info(`Using Elixir ${elixirVersion}`)
     }
-
   } else {
     throw new Error(
       `Requested Elixir / Erlang/OTP version (from spec ${exSpec0} / ${otpVersion}) not ` +

--- a/dist/index.js
+++ b/dist/index.js
@@ -4780,12 +4780,12 @@ async function getElixirVersion(exSpec0, otpVersion) {
     if (elixirVersions.get(elixirVersion).includes(otpMatch[1])) {
       // ... and it's available: use it!
       elixirVersionWithOTP = `${elixirVersion}-otp-${otpVersionMajor}`
-      core.info(`Using Elixir / -otp- version ${elixirVersionWithOTP}`)
     } else {
       // ... and it's not available: fallback to the "generic" version (v1.4.5 only).
       elixirVersionWithOTP = elixirVersion
-      core.info(`Using Elixir ${elixirVersionWithOTP}`)
     }
+
+    core.info(`Using Elixir ${elixirVersionWithOTP}`)
   } else {
     throw new Error(
       `Requested Elixir / Erlang/OTP version (from spec ${exSpec0} / ${otpVersion}) not ` +

--- a/dist/index.js
+++ b/dist/index.js
@@ -4780,12 +4780,13 @@ async function getElixirVersion(exSpec0, otpVersion) {
     if (elixirVersions.get(elixirVersion).includes(otpMatch[1])) {
       // ... and it's available: use it!
       elixirVersionWithOTP = `${elixirVersion}-otp-${otpVersionMajor}`
+      core.info(`Using Elixir ${elixirVersion} (built for OTP ${otpVersionMajor})`)
     } else {
       // ... and it's not available: fallback to the "generic" version (v1.4.5 only).
       elixirVersionWithOTP = elixirVersion
+      core.info(`Using Elixir ${elixirVersion}`)
     }
 
-    core.info(`Using Elixir ${elixirVersionWithOTP}`)
   } else {
     throw new Error(
       `Requested Elixir / Erlang/OTP version (from spec ${exSpec0} / ${otpVersion}) not ` +

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -144,12 +144,13 @@ async function getElixirVersion(exSpec0, otpVersion) {
     if (elixirVersions.get(elixirVersion).includes(otpMatch[1])) {
       // ... and it's available: use it!
       elixirVersionWithOTP = `${elixirVersion}-otp-${otpVersionMajor}`
+      core.info(`Using Elixir ${elixirVersion} (built for OTP ${otpVersionMajor})`)
     } else {
       // ... and it's not available: fallback to the "generic" version (v1.4.5 only).
       elixirVersionWithOTP = elixirVersion
+      core.info(`Using Elixir ${elixirVersion}`)
     }
 
-    core.info(`Using Elixir ${elixirVersionWithOTP}`)
   } else {
     throw new Error(
       `Requested Elixir / Erlang/OTP version (from spec ${exSpec0} / ${otpVersion}) not ` +

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -144,12 +144,12 @@ async function getElixirVersion(exSpec0, otpVersion) {
     if (elixirVersions.get(elixirVersion).includes(otpMatch[1])) {
       // ... and it's available: use it!
       elixirVersionWithOTP = `${elixirVersion}-otp-${otpVersionMajor}`
-      core.info(`Using Elixir / -otp- version ${elixirVersionWithOTP}`)
     } else {
       // ... and it's not available: fallback to the "generic" version (v1.4.5 only).
       elixirVersionWithOTP = elixirVersion
-      core.info(`Using Elixir ${elixirVersionWithOTP}`)
     }
+
+    core.info(`Using Elixir ${elixirVersionWithOTP}`)
   } else {
     throw new Error(
       `Requested Elixir / Erlang/OTP version (from spec ${exSpec0} / ${otpVersion}) not ` +

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -144,13 +144,14 @@ async function getElixirVersion(exSpec0, otpVersion) {
     if (elixirVersions.get(elixirVersion).includes(otpMatch[1])) {
       // ... and it's available: use it!
       elixirVersionWithOTP = `${elixirVersion}-otp-${otpVersionMajor}`
-      core.info(`Using Elixir ${elixirVersion} (built for OTP ${otpVersionMajor})`)
+      core.info(
+        `Using Elixir ${elixirVersion} (built for OTP ${otpVersionMajor})`,
+      )
     } else {
       // ... and it's not available: fallback to the "generic" version (v1.4.5 only).
       elixirVersionWithOTP = elixirVersion
       core.info(`Using Elixir ${elixirVersion}`)
     }
-
   } else {
     throw new Error(
       `Requested Elixir / Erlang/OTP version (from spec ${exSpec0} / ${otpVersion}) not ` +


### PR DESCRIPTION
Before this patch we printed:

    Using Elixir / -otp- version v1.12.0-otp-24

The ` / -otp-` part looks a bit out of place.

After this patch, it is simply:

    Using Elixir v1.12.0-otp-24
