### PR TITLE
Allow for latest 100 rebar3 versions when fetching from GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
           node-version: '12'
       - run: npm install -g npm
       - run: npm install
-      - run: npm run format
+      - run: npm run build
       - run: npm install -g markdownlint-cli
       - run: npm run markdownlint
       - run: npm run shellcheck
       - run: npm run yamllint
       - run: npm run jslint
       - run: npm run licenses
-      - run: npm run build
+      - run: npm run format
       - name: Check if build left artifacts
         run: git diff --exit-code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
             os: 'ubuntu-16.04'
           - elixir-version: 'v1.4'
             otp-version: '20'
-            rebar3-version: '3.11'
+            rebar3-version: '3.6.0'
             os: 'ubuntu-18.04'
           - elixir-version: 'v1.4'
             otp-version: '20'

--- a/__tests__/setup-beam.test.js
+++ b/__tests__/setup-beam.test.js
@@ -154,18 +154,18 @@ async function testRebar3Versions() {
   let expected
   let spec
 
-  spec = '3.13.x'
-  expected = '3.13.2'
+  spec = '3.10.x'
+  expected = '3.10.0'
   got = await setupElixir.getRebar3Version(spec)
   assert.deepStrictEqual(got, expected)
 
-  spec = '3.13.2'
-  expected = '3.13.2'
+  spec = '3.10.0'
+  expected = '3.10.0'
   got = await setupElixir.getRebar3Version(spec)
   assert.deepStrictEqual(got, expected)
 
-  spec = '3.13'
-  expected = '3.13.2'
+  spec = '3.10'
+  expected = '3.10.0'
   got = await setupElixir.getRebar3Version(spec)
   assert.deepStrictEqual(got, expected)
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -4859,7 +4859,7 @@ async function getElixirVersions() {
 
 async function getRebar3Versions() {
   const resultJSON = await get(
-    'https://api.github.com/repos/erlang/rebar3/releases',
+    'https://api.github.com/repos/erlang/rebar3/releases?per_page=100',
   )
   const rebar3VersionsListing = JSON.parse(resultJSON)
     .map((x) => x.tag_name)

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -223,7 +223,7 @@ async function getElixirVersions() {
 
 async function getRebar3Versions() {
   const resultJSON = await get(
-    'https://api.github.com/repos/erlang/rebar3/releases',
+    'https://api.github.com/repos/erlang/rebar3/releases?per_page=100',
   )
   const rebar3VersionsListing = JSON.parse(resultJSON)
     .map((x) => x.tag_name)


### PR DESCRIPTION
Closes #40.
Also closes #39.

**Edit**: after this one's approved and merged we could think about 1.7.2, since there's also a recent patch by @wojtekmach in the queue.