### PR TITLE
Don't preprend v when elixir version does not start with digits

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -103,6 +103,9 @@ jobs:
           - elixir-version: '1.10.3'
             otp-version: '22.3.4.1'
             os: 'ubuntu-20.04'
+          - elixir-version: 'master'
+            otp-version: '23.1'
+            os:  'ubuntu-20.04'
     steps:
       - uses: actions/checkout@v2
       - name: Use erlef/setup-beam

--- a/__tests__/setup-beam.test.js
+++ b/__tests__/setup-beam.test.js
@@ -187,6 +187,14 @@ async function testElixirVersions() {
   got = await setupBeam.getElixirVersion(spec, otpVersion)
   assert.deepStrictEqual(got, expected)
   simulateInput('version-type', 'loose')
+
+  simulateInput('version-type', 'strict')
+  spec = 'master'
+  otpVersion = '23.1'
+  expected = 'master-otp-23'
+  got = await setupBeam.getElixirVersion(spec, otpVersion)
+  assert.deepStrictEqual(got, expected)
+  simulateInput('version-type', 'loose')
 }
 
 async function testRebar3Versions() {

--- a/dist/index.js
+++ b/dist/index.js
@@ -4830,7 +4830,10 @@ async function getElixirVersion(exSpec0, otpVersion) {
     )
   }
 
-  return `v${elixirVersionWithOTP}`
+  const DigitStart = new RegExp('^\\d+')
+  return DigitStart.test(elixirVersion)
+    ? `v${elixirVersionWithOTP}`
+    : elixirVersionWithOTP
 }
 
 async function getRebar3Version(r3Spec) {

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -174,7 +174,10 @@ async function getElixirVersion(exSpec0, otpVersion) {
     )
   }
 
-  return `v${elixirVersionWithOTP}`
+  const DigitStart = new RegExp('^\\d+')
+  return DigitStart.test(elixirVersion)
+    ? `v${elixirVersionWithOTP}`
+    : elixirVersionWithOTP
 }
 
 async function getRebar3Version(r3Spec) {


### PR DESCRIPTION
Closes #60 

This commit conditionally prepends `v` on an elixir version. Specifically, when the elixir version starts with digit, we prepend `v`, otherwise we leave it as is. 