### PR TITLE
Mention what problem matchers do in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ workflow by:
 - optionally, installing Gleam
 - optionally, installing `rebar3`
 - optionally, installing `hex`
+- Configures [problem matchers](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md) to show warnings and errors on PR's
 
 **Note** Currently, this action only supports Actions' `ubuntu-` and `windows-` runtimes.
 


### PR DESCRIPTION
Otherwise it is difficult to know that the erlef/setup-beam matchers are what is creating the warning/error annotations on PR's