### PR TITLE
Allow disabling problem matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ workflow by:
 - optionally, installing Gleam
 - optionally, installing `rebar3`
 - optionally, installing `hex`
-- Configures [problem matchers](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md) to show warnings and errors on PR's
+- optionally, having
+  [problem matchers](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md) show
+  warnings and errors on pull requests
 
 **Note** Currently, this action only supports Actions' `ubuntu-` and `windows-` runtimes.
 
@@ -170,7 +172,9 @@ jobs:
 
 ## Elixir Problem Matchers
 
-The Elixir Problem Matchers in this repository are adapted from [here](https://github.com/fr1zle/vscode-elixir/blob/45eddb589acd7ac98e0c7305d1c2b24668ca709a/package.json#L70-L118). See [MATCHER_NOTICE](MATCHER_NOTICE.md) for license details.
+The Elixir Problem Matchers in this repository are adapted from
+[here](https://github.com/fr1zle/vscode-elixir/blob/45eddb589acd7ac98e0c7305d1c2b24668ca709a/package.json#L70-L118).
+See [MATCHER_NOTICE](MATCHER_NOTICE.md) for license details.
 
 ## Action versioning
 

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
     description: strict means the versions are take as-are; loose means we try
       to guess versions based on semver rules
     default: loose
+  disable_problem_matchers:
+    description: whether to have the problem matchers present in the results (or not)
+    default: false
 outputs:
   elixir-version:
     description: Exact version of Elixir that was installed

--- a/dist/index.js
+++ b/dist/index.js
@@ -4738,10 +4738,15 @@ async function maybeInstallElixir(elixirSpec, otpVersion) {
     console.log(`##[group]Installing Elixir ${elixirVersion}`)
     await installer.installElixir(elixirVersion)
     core.setOutput('elixir-version', elixirVersion)
-    const matchersPath = __nccwpck_require__.ab + ".github"
-    console.log(
-      `##[add-matcher]${path.join(matchersPath, 'elixir-matchers.json')}`,
-    )
+    const disableProblemMatchers = core.getInput('disable_problem_matchers', {
+      required: false,
+    })
+    if (!disableProblemMatchers) {
+      const matchersPath = __nccwpck_require__.ab + ".github"
+      console.log(
+        `##[add-matcher]${path.join(matchersPath, 'elixir-matchers.json')}`,
+      )
+    }
     core.addPath(`${process.env.RUNNER_TEMP}/.setup-beam/elixir/bin`)
     console.log('##[endgroup]')
 

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -66,10 +66,15 @@ async function maybeInstallElixir(elixirSpec, otpVersion) {
     console.log(`##[group]Installing Elixir ${elixirVersion}`)
     await installer.installElixir(elixirVersion)
     core.setOutput('elixir-version', elixirVersion)
-    const matchersPath = path.join(__dirname, '..', '.github')
-    console.log(
-      `##[add-matcher]${path.join(matchersPath, 'elixir-matchers.json')}`,
-    )
+    const disableProblemMatchers = core.getInput('disable_problem_matchers', {
+      required: false,
+    })
+    if (!disableProblemMatchers) {
+      const matchersPath = path.join(__dirname, '..', '.github')
+      console.log(
+        `##[add-matcher]${path.join(matchersPath, 'elixir-matchers.json')}`,
+      )
+    }
     core.addPath(`${process.env.RUNNER_TEMP}/.setup-beam/elixir/bin`)
     console.log('##[endgroup]')
 


### PR DESCRIPTION
Closes #77.

@hauleth, let me know if this change is good for you, as is. It's not `enable_`, since that was the default, but it serves the same purpose.