### PR TITLE
Fix 3rd party license updater (automation)

### DIFF
--- a/.github/workflows/update_3rd_party_licenses.sh
+++ b/.github/workflows/update_3rd_party_licenses.sh
@@ -4,10 +4,25 @@ set -eux
 
 git config user.name "GitHub Actions"
 git config user.email "actions@user.noreply.github.com"
-git checkout main
 
+BRANCH=feature/3rd-party-licenses-update
+
+if git branch -a | grep "$BRANCH" > /dev/null; then
+    # already exists
+    exit
+fi
+
+git fetch origin
+git checkout -b "$BRANCH"
 npm run licenses
 
-git add 3RD_PARTY_LICENSES
-git commit -m "Update 3rd party licenses" || true
-git push origin
+if ! git diff --exit-code 1> /dev/null ; then
+    # there's stuff to push
+    git add 3RD_PARTY_LICENSES
+    git commit -m "Update 3rd party licenses"
+    git push origin "$BRANCH"
+
+    gh pr create --fill \
+        --title "Update 3rd party licenses (automation)" \
+        --body "This is an automated action to update the action's 3rd party licenses"
+fi

--- a/.github/workflows/update_3rd_party_licenses.yml
+++ b/.github/workflows/update_3rd_party_licenses.yml
@@ -17,3 +17,5 @@ jobs:
           node-version: '14'
       - run:
           ./.github/workflows/update_3rd_party_licenses.sh
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Instead of pushing directly, since the `main` branch is protected, this creates a pull request.

Failure: https://github.com/erlef/setup-beam/actions/runs/1852644324

It's possible this pull request doesn't pass CI since the 3rd party licenses are outdated, but once it's accepted+merged in at most 24h stuff should be back to normal.