### PR TITLE
Attempt use on top of Erlang 25.0-rc1

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -21,6 +21,9 @@ jobs:
       fail-fast: false
       matrix:
         combo:
+          - otp-version: '25.0-rc1'
+            rebar3-version: 'nightly'
+            os: 'ubuntu-latest'
           - otp-version: '24'
             rebar3-version: 'nightly'
             os: 'ubuntu-latest'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,6 +21,9 @@ jobs:
       fail-fast: false
       matrix:
         combo:
+          - otp-version: '25.0-rc1'
+            rebar3-version: 'nightly'
+            os: 'windows-latest'
           - otp-version: '24.0.2'
             rebar3-version: '3.16'
             os: 'windows-2019'


### PR DESCRIPTION
⚠️ don't merge before #91+#92 and the 3rd party licenses are update (lest we have "expected" errors which don't tell the whole story)

Checking how this all behaves with `25.0-rc1`.