### PR TITLE
Add environment variables

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -149,3 +149,32 @@ jobs:
           cd test-projects/gleam_gleam
           gleam test
         if: ${{ matrix.combo.gleam-version && matrix.combo.otp-version && !matrix.combo.rebar3-version }}
+  environment_variables:
+    name: Environment variables
+    runs-on: ${{matrix.combo.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        combo:
+          - otp-version: '24'
+            elixir-version: 'v1.12'
+            gleam-version: '0.19'
+            rebar3-version: 'nightly'
+            os: 'ubuntu-latest'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use erlef/setup-beam
+        id: setup-beam
+        uses: ./
+        with:
+          otp-version: ${{matrix.combo.otp-version}}
+          elixir-version: ${{matrix.combo.elixir-version}}
+          gleam-version: ${{matrix.combo.gleam-version}}
+          rebar3-version: ${{matrix.combo.rebar3-version}}
+      - run: env
+      - name: List environment variables
+        run: |
+          echo "${{env.INSTALL_DIR_FOR_ELIXIR}}"
+          echo "${{env.INSTALL_DIR_FOR_GLEAM}}"
+          echo "${{env.INSTALL_DIR_FOR_OTP}}"
+          echo "${{env.INSTALL_DIR_FOR_REBAR3}}"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -84,3 +84,32 @@ jobs:
           cd test-projects/gleam_rebar3
           rebar3 eunit
         if: ${{matrix.combo.gleam-version}}
+  environment_variables:
+    name: Environment variables
+    runs-on: ${{matrix.combo.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        combo:
+          - otp-version: '24'
+            elixir-version: 'v1.12'
+            gleam-version: '0.19'
+            rebar3-version: 'nightly'
+            os: 'windows-latest'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use erlef/setup-beam
+        id: setup-beam
+        uses: ./
+        with:
+          otp-version: ${{matrix.combo.otp-version}}
+          elixir-version: ${{matrix.combo.elixir-version}}
+          gleam-version: ${{matrix.combo.gleam-version}}
+          rebar3-version: ${{matrix.combo.rebar3-version}}
+      - run: env
+      - name: List environment variables
+        run: |
+          echo "${{env.INSTALL_DIR_FOR_ELIXIR}}"
+          echo "${{env.INSTALL_DIR_FOR_GLEAM}}"
+          echo "${{env.INSTALL_DIR_FOR_OTP}}"
+          echo "${{env.INSTALL_DIR_FOR_REBAR3}}"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ and Erlang/OTP.
 | ubuntu-18.04     | 17 - 24    | ✅
 | ubuntu-20.04     | 20 - 24    | ✅
 | windows-2019     | 21* - 24   | ✅
+| windows-2022     | 21* - 24   | ✅
 
 **Note** *: prior to 23, Windows builds are only available for minor versions, e.g. 21.0, 21.3, 22.0, etc.
 
@@ -65,6 +66,7 @@ uses that to download assets:
 | ubuntu18 | ubuntu-18.04
 | ubuntu20 | ubuntu-20.04
 | win19    | windows-2019
+| win22    | windows-2022
 
 as per the following example:
 
@@ -137,7 +139,7 @@ on: push
 
 jobs:
   test:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/README.md
+++ b/README.md
@@ -187,6 +187,16 @@ jobs:
 
 **Note**: the `otp-version: false` input is only applicable when installing Gleam.
 
+## Environment variables
+
+Base installation folders (useful for e.g. fetching headers for NIFs) are available in the following
+environment variables:
+
+- `INSTALL_DIR_FOR_ELIXIR`: base folder for Erlang/OTP
+- `INSTALL_DIR_FOR_GLEAM`: base folder for Elixir
+- `INSTALL_DIR_FOR_OTP`: base folder for Gleam
+- `INSTALL_DIR_FOR_REBAR3`: base folder for `rebar3`
+
 ## Elixir Problem Matchers
 
 The Elixir Problem Matchers in this repository are adapted from

--- a/dist/index.js
+++ b/dist/index.js
@@ -6378,6 +6378,7 @@ function getRunnerOSVersion() {
     ubuntu18: 'ubuntu-18.04',
     ubuntu20: 'ubuntu-20.04',
     win19: 'windows-2019',
+    win22: 'windows-2022',
   }
   const containerFromEnvImageOS = ImageOSToContainer[process.env.ImageOS]
 

--- a/dist/install-elixir.ps1
+++ b/dist/install-elixir.ps1
@@ -17,3 +17,5 @@ Expand-Archive -DestinationPath "${DIR_FOR_BIN}" -Path "${FILE_OUTPUT}"
 $ProgressPreference="Continue"
 Write-Output "Installed Elixir version follows"
 & "$DIR_FOR_BIN/bin/elixir" "-v" | Write-Output
+
+"INSTALL_DIR_FOR_ELIXIR=${Env:RUNNER_TEMP}/${DIR_FOR_BIN}" | Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append

--- a/dist/install-elixir.ps1
+++ b/dist/install-elixir.ps1
@@ -1,21 +1,21 @@
-param([Parameter(Mandatory=$true)][string]$VSN)
+param([Parameter(Mandatory=$true)][string]${VSN})
 
 $ErrorActionPreference="Stop"
 
-Set-Location $Env:RUNNER_TEMP
+Set-Location ${Env:RUNNER_TEMP}
 
 $FILE_INPUT="${VSN}.zip"
 $FILE_OUTPUT="elixir.zip"
 $DIR_FOR_BIN=".setup-beam/elixir"
 
 $ProgressPreference="SilentlyContinue"
-Invoke-WebRequest "https://repo.hex.pm/builds/elixir/${FILE_INPUT}" -OutFile "$FILE_OUTPUT"
+Invoke-WebRequest "https://repo.hex.pm/builds/elixir/${FILE_INPUT}" -OutFile "${FILE_OUTPUT}"
 $ProgressPreference="Continue"
-New-Item "$DIR_FOR_BIN" -ItemType Directory | Out-Null
+New-Item "${DIR_FOR_BIN}" -ItemType Directory | Out-Null
 $ProgressPreference="SilentlyContinue"
 Expand-Archive -DestinationPath "${DIR_FOR_BIN}" -Path "${FILE_OUTPUT}"
 $ProgressPreference="Continue"
 Write-Output "Installed Elixir version follows"
-& "$DIR_FOR_BIN/bin/elixir" "-v" | Write-Output
+& "${DIR_FOR_BIN}/bin/elixir" "-v" | Write-Output
 
 "INSTALL_DIR_FOR_ELIXIR=${Env:RUNNER_TEMP}/${DIR_FOR_BIN}" | Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append

--- a/dist/install-elixir.sh
+++ b/dist/install-elixir.sh
@@ -14,3 +14,5 @@ mkdir -p "${DIR_FOR_BIN}"
 unzip -q -d "${DIR_FOR_BIN}" "${FILE_OUTPUT}"
 echo "Installed Elixir version follows"
 ${DIR_FOR_BIN}/bin/elixir -v
+
+echo "INSTALL_DIR_FOR_ELIXIR=${RUNNER_TEMP}/${DIR_FOR_BIN}" >> "${GITHUB_ENV}"

--- a/dist/install-elixir.sh
+++ b/dist/install-elixir.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-cd "$RUNNER_TEMP"
+cd "${RUNNER_TEMP}"
 
 VSN=${1}
 FILE_INPUT="${VSN}.zip"

--- a/dist/install-gleam.ps1
+++ b/dist/install-gleam.ps1
@@ -6,14 +6,16 @@ Set-Location $Env:RUNNER_TEMP
 
 $FILE_INPUT="gleam-${VSN}-windows-64bit.zip"
 $FILE_OUTPUT="gleam.zip"
-$DIR_FOR_BIN=".setup-beam/gleam/bin"
+$DIR_FOR_BIN=".setup-beam/gleam"
 
 $ProgressPreference="SilentlyContinue"
 Invoke-WebRequest "https://github.com/gleam-lang/gleam/releases/download/${VSN}/${FILE_INPUT}" -OutFile "$FILE_OUTPUT"
 $ProgressPreference="Continue"
-New-Item "$DIR_FOR_BIN" -ItemType Directory | Out-Null
+New-Item "${DIR_FOR_BIN}/bin" -ItemType Directory | Out-Null
 $ProgressPreference="SilentlyContinue"
-Expand-Archive -DestinationPath "${DIR_FOR_BIN}" -Path "${FILE_OUTPUT}"
+Expand-Archive -DestinationPath "${DIR_FOR_BIN}/bin" -Path "${FILE_OUTPUT}"
 $ProgressPreference="Continue"
 Write-Output "Installed Gleam version follows"
-& "$DIR_FOR_BIN/gleam" "--version" | Write-Output
+& "${DIR_FOR_BIN}/bin/gleam" "--version" | Write-Output
+
+"INSTALL_DIR_FOR_GLEAM=${Env:RUNNER_TEMP}/${DIR_FOR_BIN}" | Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append

--- a/dist/install-gleam.ps1
+++ b/dist/install-gleam.ps1
@@ -1,15 +1,15 @@
-param([Parameter(Mandatory=$true)][string]$VSN)
+param([Parameter(Mandatory=$true)][string]${VSN})
 
 $ErrorActionPreference="Stop"
 
-Set-Location $Env:RUNNER_TEMP
+Set-Location ${Env:RUNNER_TEMP}
 
 $FILE_INPUT="gleam-${VSN}-windows-64bit.zip"
 $FILE_OUTPUT="gleam.zip"
 $DIR_FOR_BIN=".setup-beam/gleam"
 
 $ProgressPreference="SilentlyContinue"
-Invoke-WebRequest "https://github.com/gleam-lang/gleam/releases/download/${VSN}/${FILE_INPUT}" -OutFile "$FILE_OUTPUT"
+Invoke-WebRequest "https://github.com/gleam-lang/gleam/releases/download/${VSN}/${FILE_INPUT}" -OutFile "${FILE_OUTPUT}"
 $ProgressPreference="Continue"
 New-Item "${DIR_FOR_BIN}/bin" -ItemType Directory | Out-Null
 $ProgressPreference="SilentlyContinue"

--- a/dist/install-gleam.sh
+++ b/dist/install-gleam.sh
@@ -7,11 +7,13 @@ cd "$RUNNER_TEMP"
 VSN=${1}
 FILE_INPUT=gleam-${VSN}-linux-amd64.tar.gz
 FILE_OUTPUT=gleam.tar.gz
-DIR_FOR_BIN=.setup-beam/gleam/bin
+DIR_FOR_BIN=.setup-beam/gleam
 
 wget -q -O "${FILE_OUTPUT}" "https://github.com/gleam-lang/gleam/releases/download/${VSN}/${FILE_INPUT}"
-mkdir -p "${DIR_FOR_BIN}"
-tar zxf "${FILE_OUTPUT}" -C "${DIR_FOR_BIN}"
+mkdir -p "${DIR_FOR_BIN}/bin"
+tar zxf "${FILE_OUTPUT}" -C "${DIR_FOR_BIN}/bin"
 
 echo "Installed Gleam version follows"
-${DIR_FOR_BIN}/gleam --version
+${DIR_FOR_BIN}/bin/gleam --version
+
+echo "INSTALL_DIR_FOR_GLEAM=${RUNNER_TEMP}/${DIR_FOR_BIN}" >> "${GITHUB_ENV}"

--- a/dist/install-gleam.sh
+++ b/dist/install-gleam.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-cd "$RUNNER_TEMP"
+cd "${RUNNER_TEMP}"
 
 VSN=${1}
 FILE_INPUT=gleam-${VSN}-linux-amd64.tar.gz

--- a/dist/install-otp.ps1
+++ b/dist/install-otp.ps1
@@ -1,22 +1,22 @@
-param([Parameter(Mandatory=$true)][string]$VSN)
+param([Parameter(Mandatory=$true)][string]${VSN})
 
 $ErrorActionPreference="Stop"
 
-Set-Location $Env:RUNNER_TEMP
+Set-Location ${Env:RUNNER_TEMP}
 
 $FILE_OUTPUT="otp.exe"
 $DIR_FOR_BIN=".setup-beam/otp"
 
 $ProgressPreference="SilentlyContinue"
-Invoke-WebRequest "https://github.com/erlang/otp/releases/download/OTP-$VSN/otp_win64_$VSN.exe" -OutFile "$FILE_OUTPUT"
+Invoke-WebRequest "https://github.com/erlang/otp/releases/download/OTP-${VSN}/otp_win64_${VSN}.exe" -OutFile "${FILE_OUTPUT}"
 $ProgressPreference="Continue"
-New-Item "$DIR_FOR_BIN" -ItemType Directory | Out-Null
-Move-Item "$FILE_OUTPUT" "$DIR_FOR_BIN"
-Start-Process "./$DIR_FOR_BIN/$FILE_OUTPUT" /S -Wait
+New-Item "${DIR_FOR_BIN}" -ItemType Directory | Out-Null
+Move-Item "${FILE_OUTPUT}" "${DIR_FOR_BIN}"
+Start-Process "./${DIR_FOR_BIN}/${FILE_OUTPUT}" /S -Wait
 $ErlExec = Get-ChildItem -Path "C:/Program Files/" -Recurse -Depth 2 -Filter 'erl.exe' -Name | ForEach-Object { Write-Output "C:/Program Files/$_" }
-$ErlPath = Split-Path -Path "$ErlExec"
-Write-Output "$ErlPath" | Out-File -FilePath otp_path.txt -Encoding utf8 -NoNewline
+$ErlPath = Split-Path -Path "${ErlExec}"
+Write-Output "${ErlPath}" | Out-File -FilePath otp_path.txt -Encoding utf8 -NoNewline
 Write-Output "Installed Erlang/OTP version follows"
-& "$ErlPath/erl.exe" "+V" | Write-Output
+& "${ErlPath}/erl.exe" "+V" | Write-Output
 
 "INSTALL_DIR_FOR_OTP="+(Get-Item ${ErlPath}).parent.FullName | Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append

--- a/dist/install-otp.ps1
+++ b/dist/install-otp.ps1
@@ -18,3 +18,5 @@ $ErlPath = Split-Path -Path "$ErlExec"
 Write-Output "$ErlPath" | Out-File -FilePath otp_path.txt -Encoding utf8 -NoNewline
 Write-Output "Installed Erlang/OTP version follows"
 & "$ErlPath/erl.exe" "+V" | Write-Output
+
+"INSTALL_DIR_FOR_OTP="+(Get-Item ${ErlPath}).parent.FullName | Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append

--- a/dist/install-otp.sh
+++ b/dist/install-otp.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-cd "$RUNNER_TEMP"
+cd "${RUNNER_TEMP}"
 
 OS=${1}
 VSN=${2}

--- a/dist/install-otp.sh
+++ b/dist/install-otp.sh
@@ -16,3 +16,5 @@ tar zxf "${FILE_OUTPUT}" -C "${DIR_FOR_BIN}" --strip-components=1
 "${DIR_FOR_BIN}/Install" -minimal "$(pwd)/${DIR_FOR_BIN}"
 echo "Installed Erlang/OTP version follows"
 ${DIR_FOR_BIN}/bin/erl -version
+
+echo "INSTALL_DIR_FOR_OTP=${RUNNER_TEMP}/${DIR_FOR_BIN}" >> "${GITHUB_ENV}"

--- a/dist/install-rebar3.ps1
+++ b/dist/install-rebar3.ps1
@@ -1,8 +1,8 @@
-param([Parameter(Mandatory=$true)][string]$VSN)
+param([Parameter(Mandatory=$true)][string]${VSN})
 
 $ErrorActionPreference="Stop"
 
-Set-Location $Env:RUNNER_TEMP
+Set-Location ${Env:RUNNER_TEMP}
 
 $FILE_INPUT="rebar3"
 $FILE_OUTPUT="rebar3"
@@ -12,19 +12,19 @@ $DIR_FOR_BIN=".setup-beam/rebar3"
 $ProgressPreference="SilentlyContinue"
 $REBAR3_TARGET="https://github.com/erlang/rebar3/releases/download/${VSN}/${FILE_INPUT}"
 $REBAR3_NIGHTLY=""
-If ( $VSN -eq "nightly" )
+If ( ${VSN} -eq "nightly" )
 {
     $REBAR3_TARGET="https://s3.amazonaws.com/rebar3-nightly/rebar3"
     $REBAR3_NIGHTLY=" (from nightly build)"
 }
-Invoke-WebRequest "$REBAR3_TARGET" -OutFile "$FILE_OUTPUT"
+Invoke-WebRequest "${REBAR3_TARGET}" -OutFile "${FILE_OUTPUT}"
 $ProgressPreference="Continue"
-New-Item "$DIR_FOR_BIN/bin" -ItemType Directory | Out-Null
-Move-Item "$FILE_OUTPUT" "$DIR_FOR_BIN/bin"
-Write-Output "& escript.exe $PWD/$DIR_FOR_BIN/bin/$FILE_OUTPUT `$args" | Out-File -FilePath "$FILE_OUTPUT_PS1" -Encoding utf8 -Append
-type $FILE_OUTPUT_PS1
-Move-Item "$FILE_OUTPUT_PS1" "$DIR_FOR_BIN/bin"
-Write-Output "Installed rebar3 version$REBAR3_NIGHTLY follows"
-& "$DIR_FOR_BIN/bin/rebar3" "version" | Write-Output
+New-Item "${DIR_FOR_BIN}/bin" -ItemType Directory | Out-Null
+Move-Item "${FILE_OUTPUT}" "${DIR_FOR_BIN}/bin"
+Write-Output "& escript.exe ${PWD}/${DIR_FOR_BIN}/bin/${FILE_OUTPUT} `${args}" | Out-File -FilePath "${FILE_OUTPUT_PS1}" -Encoding utf8 -Append
+type ${FILE_OUTPUT_PS1}
+Move-Item "${FILE_OUTPUT_PS1}" "${DIR_FOR_BIN}/bin"
+Write-Output "Installed rebar3 version${REBAR3_NIGHTLY} follows"
+& "${DIR_FOR_BIN}/bin/rebar3" "version" | Write-Output
 
 "INSTALL_DIR_FOR_REBAR3=${Env:RUNNER_TEMP}/${DIR_FOR_BIN}" | Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append

--- a/dist/install-rebar3.ps1
+++ b/dist/install-rebar3.ps1
@@ -26,3 +26,5 @@ type $FILE_OUTPUT_PS1
 Move-Item "$FILE_OUTPUT_PS1" "$DIR_FOR_BIN/bin"
 Write-Output "Installed rebar3 version$REBAR3_NIGHTLY follows"
 & "$DIR_FOR_BIN/bin/rebar3" "version" | Write-Output
+
+"INSTALL_DIR_FOR_REBAR3=${Env:RUNNER_TEMP}/${DIR_FOR_BIN}" | Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append

--- a/dist/install-rebar3.sh
+++ b/dist/install-rebar3.sh
@@ -21,3 +21,5 @@ chmod +x "${FILE_OUTPUT}"
 mv "${FILE_OUTPUT}" "${DIR_FOR_BIN}/bin"
 echo "Installed rebar3 version$REBAR3_NIGHTLY follows"
 ${DIR_FOR_BIN}/bin/rebar3 version
+
+echo "INSTALL_DIR_FOR_REBAR3=${RUNNER_TEMP}/${DIR_FOR_BIN}" >> "${GITHUB_ENV}"

--- a/dist/install-rebar3.sh
+++ b/dist/install-rebar3.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-cd "$RUNNER_TEMP"
+cd "${RUNNER_TEMP}"
 
 VSN=${1}
 FILE_INPUT=rebar3
@@ -19,7 +19,7 @@ wget -q -O "${FILE_OUTPUT}" "${REBAR3_TARGET}"
 mkdir -p "${DIR_FOR_BIN}/bin"
 chmod +x "${FILE_OUTPUT}"
 mv "${FILE_OUTPUT}" "${DIR_FOR_BIN}/bin"
-echo "Installed rebar3 version$REBAR3_NIGHTLY follows"
+echo "Installed rebar3 version${REBAR3_NIGHTLY} follows"
 ${DIR_FOR_BIN}/bin/rebar3 version
 
 echo "INSTALL_DIR_FOR_REBAR3=${RUNNER_TEMP}/${DIR_FOR_BIN}" >> "${GITHUB_ENV}"

--- a/src/install-elixir.ps1
+++ b/src/install-elixir.ps1
@@ -17,3 +17,5 @@ Expand-Archive -DestinationPath "${DIR_FOR_BIN}" -Path "${FILE_OUTPUT}"
 $ProgressPreference="Continue"
 Write-Output "Installed Elixir version follows"
 & "$DIR_FOR_BIN/bin/elixir" "-v" | Write-Output
+
+"INSTALL_DIR_FOR_ELIXIR=${Env:RUNNER_TEMP}/${DIR_FOR_BIN}" | Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append

--- a/src/install-elixir.ps1
+++ b/src/install-elixir.ps1
@@ -1,21 +1,21 @@
-param([Parameter(Mandatory=$true)][string]$VSN)
+param([Parameter(Mandatory=$true)][string]${VSN})
 
 $ErrorActionPreference="Stop"
 
-Set-Location $Env:RUNNER_TEMP
+Set-Location ${Env:RUNNER_TEMP}
 
 $FILE_INPUT="${VSN}.zip"
 $FILE_OUTPUT="elixir.zip"
 $DIR_FOR_BIN=".setup-beam/elixir"
 
 $ProgressPreference="SilentlyContinue"
-Invoke-WebRequest "https://repo.hex.pm/builds/elixir/${FILE_INPUT}" -OutFile "$FILE_OUTPUT"
+Invoke-WebRequest "https://repo.hex.pm/builds/elixir/${FILE_INPUT}" -OutFile "${FILE_OUTPUT}"
 $ProgressPreference="Continue"
-New-Item "$DIR_FOR_BIN" -ItemType Directory | Out-Null
+New-Item "${DIR_FOR_BIN}" -ItemType Directory | Out-Null
 $ProgressPreference="SilentlyContinue"
 Expand-Archive -DestinationPath "${DIR_FOR_BIN}" -Path "${FILE_OUTPUT}"
 $ProgressPreference="Continue"
 Write-Output "Installed Elixir version follows"
-& "$DIR_FOR_BIN/bin/elixir" "-v" | Write-Output
+& "${DIR_FOR_BIN}/bin/elixir" "-v" | Write-Output
 
 "INSTALL_DIR_FOR_ELIXIR=${Env:RUNNER_TEMP}/${DIR_FOR_BIN}" | Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append

--- a/src/install-elixir.sh
+++ b/src/install-elixir.sh
@@ -14,3 +14,5 @@ mkdir -p "${DIR_FOR_BIN}"
 unzip -q -d "${DIR_FOR_BIN}" "${FILE_OUTPUT}"
 echo "Installed Elixir version follows"
 ${DIR_FOR_BIN}/bin/elixir -v
+
+echo "INSTALL_DIR_FOR_ELIXIR=${RUNNER_TEMP}/${DIR_FOR_BIN}" >> "${GITHUB_ENV}"

--- a/src/install-elixir.sh
+++ b/src/install-elixir.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-cd "$RUNNER_TEMP"
+cd "${RUNNER_TEMP}"
 
 VSN=${1}
 FILE_INPUT="${VSN}.zip"

--- a/src/install-gleam.ps1
+++ b/src/install-gleam.ps1
@@ -6,14 +6,16 @@ Set-Location $Env:RUNNER_TEMP
 
 $FILE_INPUT="gleam-${VSN}-windows-64bit.zip"
 $FILE_OUTPUT="gleam.zip"
-$DIR_FOR_BIN=".setup-beam/gleam/bin"
+$DIR_FOR_BIN=".setup-beam/gleam"
 
 $ProgressPreference="SilentlyContinue"
 Invoke-WebRequest "https://github.com/gleam-lang/gleam/releases/download/${VSN}/${FILE_INPUT}" -OutFile "$FILE_OUTPUT"
 $ProgressPreference="Continue"
-New-Item "$DIR_FOR_BIN" -ItemType Directory | Out-Null
+New-Item "${DIR_FOR_BIN}/bin" -ItemType Directory | Out-Null
 $ProgressPreference="SilentlyContinue"
-Expand-Archive -DestinationPath "${DIR_FOR_BIN}" -Path "${FILE_OUTPUT}"
+Expand-Archive -DestinationPath "${DIR_FOR_BIN}/bin" -Path "${FILE_OUTPUT}"
 $ProgressPreference="Continue"
 Write-Output "Installed Gleam version follows"
-& "$DIR_FOR_BIN/gleam" "--version" | Write-Output
+& "${DIR_FOR_BIN}/bin/gleam" "--version" | Write-Output
+
+"INSTALL_DIR_FOR_GLEAM=${Env:RUNNER_TEMP}/${DIR_FOR_BIN}" | Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append

--- a/src/install-gleam.ps1
+++ b/src/install-gleam.ps1
@@ -1,15 +1,15 @@
-param([Parameter(Mandatory=$true)][string]$VSN)
+param([Parameter(Mandatory=$true)][string]${VSN})
 
 $ErrorActionPreference="Stop"
 
-Set-Location $Env:RUNNER_TEMP
+Set-Location ${Env:RUNNER_TEMP}
 
 $FILE_INPUT="gleam-${VSN}-windows-64bit.zip"
 $FILE_OUTPUT="gleam.zip"
 $DIR_FOR_BIN=".setup-beam/gleam"
 
 $ProgressPreference="SilentlyContinue"
-Invoke-WebRequest "https://github.com/gleam-lang/gleam/releases/download/${VSN}/${FILE_INPUT}" -OutFile "$FILE_OUTPUT"
+Invoke-WebRequest "https://github.com/gleam-lang/gleam/releases/download/${VSN}/${FILE_INPUT}" -OutFile "${FILE_OUTPUT}"
 $ProgressPreference="Continue"
 New-Item "${DIR_FOR_BIN}/bin" -ItemType Directory | Out-Null
 $ProgressPreference="SilentlyContinue"

--- a/src/install-gleam.sh
+++ b/src/install-gleam.sh
@@ -7,11 +7,13 @@ cd "$RUNNER_TEMP"
 VSN=${1}
 FILE_INPUT=gleam-${VSN}-linux-amd64.tar.gz
 FILE_OUTPUT=gleam.tar.gz
-DIR_FOR_BIN=.setup-beam/gleam/bin
+DIR_FOR_BIN=.setup-beam/gleam
 
 wget -q -O "${FILE_OUTPUT}" "https://github.com/gleam-lang/gleam/releases/download/${VSN}/${FILE_INPUT}"
-mkdir -p "${DIR_FOR_BIN}"
-tar zxf "${FILE_OUTPUT}" -C "${DIR_FOR_BIN}"
+mkdir -p "${DIR_FOR_BIN}/bin"
+tar zxf "${FILE_OUTPUT}" -C "${DIR_FOR_BIN}/bin"
 
 echo "Installed Gleam version follows"
-${DIR_FOR_BIN}/gleam --version
+${DIR_FOR_BIN}/bin/gleam --version
+
+echo "INSTALL_DIR_FOR_GLEAM=${RUNNER_TEMP}/${DIR_FOR_BIN}" >> "${GITHUB_ENV}"

--- a/src/install-gleam.sh
+++ b/src/install-gleam.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-cd "$RUNNER_TEMP"
+cd "${RUNNER_TEMP}"
 
 VSN=${1}
 FILE_INPUT=gleam-${VSN}-linux-amd64.tar.gz

--- a/src/install-otp.ps1
+++ b/src/install-otp.ps1
@@ -1,22 +1,22 @@
-param([Parameter(Mandatory=$true)][string]$VSN)
+param([Parameter(Mandatory=$true)][string]${VSN})
 
 $ErrorActionPreference="Stop"
 
-Set-Location $Env:RUNNER_TEMP
+Set-Location ${Env:RUNNER_TEMP}
 
 $FILE_OUTPUT="otp.exe"
 $DIR_FOR_BIN=".setup-beam/otp"
 
 $ProgressPreference="SilentlyContinue"
-Invoke-WebRequest "https://github.com/erlang/otp/releases/download/OTP-$VSN/otp_win64_$VSN.exe" -OutFile "$FILE_OUTPUT"
+Invoke-WebRequest "https://github.com/erlang/otp/releases/download/OTP-${VSN}/otp_win64_${VSN}.exe" -OutFile "${FILE_OUTPUT}"
 $ProgressPreference="Continue"
-New-Item "$DIR_FOR_BIN" -ItemType Directory | Out-Null
-Move-Item "$FILE_OUTPUT" "$DIR_FOR_BIN"
-Start-Process "./$DIR_FOR_BIN/$FILE_OUTPUT" /S -Wait
+New-Item "${DIR_FOR_BIN}" -ItemType Directory | Out-Null
+Move-Item "${FILE_OUTPUT}" "${DIR_FOR_BIN}"
+Start-Process "./${DIR_FOR_BIN}/${FILE_OUTPUT}" /S -Wait
 $ErlExec = Get-ChildItem -Path "C:/Program Files/" -Recurse -Depth 2 -Filter 'erl.exe' -Name | ForEach-Object { Write-Output "C:/Program Files/$_" }
-$ErlPath = Split-Path -Path "$ErlExec"
-Write-Output "$ErlPath" | Out-File -FilePath otp_path.txt -Encoding utf8 -NoNewline
+$ErlPath = Split-Path -Path "${ErlExec}"
+Write-Output "${ErlPath}" | Out-File -FilePath otp_path.txt -Encoding utf8 -NoNewline
 Write-Output "Installed Erlang/OTP version follows"
-& "$ErlPath/erl.exe" "+V" | Write-Output
+& "${ErlPath}/erl.exe" "+V" | Write-Output
 
 "INSTALL_DIR_FOR_OTP="+(Get-Item ${ErlPath}).parent.FullName | Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append

--- a/src/install-otp.ps1
+++ b/src/install-otp.ps1
@@ -18,3 +18,5 @@ $ErlPath = Split-Path -Path "$ErlExec"
 Write-Output "$ErlPath" | Out-File -FilePath otp_path.txt -Encoding utf8 -NoNewline
 Write-Output "Installed Erlang/OTP version follows"
 & "$ErlPath/erl.exe" "+V" | Write-Output
+
+"INSTALL_DIR_FOR_OTP="+(Get-Item ${ErlPath}).parent.FullName | Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append

--- a/src/install-otp.sh
+++ b/src/install-otp.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-cd "$RUNNER_TEMP"
+cd "${RUNNER_TEMP}"
 
 OS=${1}
 VSN=${2}

--- a/src/install-otp.sh
+++ b/src/install-otp.sh
@@ -16,3 +16,5 @@ tar zxf "${FILE_OUTPUT}" -C "${DIR_FOR_BIN}" --strip-components=1
 "${DIR_FOR_BIN}/Install" -minimal "$(pwd)/${DIR_FOR_BIN}"
 echo "Installed Erlang/OTP version follows"
 ${DIR_FOR_BIN}/bin/erl -version
+
+echo "INSTALL_DIR_FOR_OTP=${RUNNER_TEMP}/${DIR_FOR_BIN}" >> "${GITHUB_ENV}"

--- a/src/install-rebar3.ps1
+++ b/src/install-rebar3.ps1
@@ -1,8 +1,8 @@
-param([Parameter(Mandatory=$true)][string]$VSN)
+param([Parameter(Mandatory=$true)][string]${VSN})
 
 $ErrorActionPreference="Stop"
 
-Set-Location $Env:RUNNER_TEMP
+Set-Location ${Env:RUNNER_TEMP}
 
 $FILE_INPUT="rebar3"
 $FILE_OUTPUT="rebar3"
@@ -12,19 +12,19 @@ $DIR_FOR_BIN=".setup-beam/rebar3"
 $ProgressPreference="SilentlyContinue"
 $REBAR3_TARGET="https://github.com/erlang/rebar3/releases/download/${VSN}/${FILE_INPUT}"
 $REBAR3_NIGHTLY=""
-If ( $VSN -eq "nightly" )
+If ( ${VSN} -eq "nightly" )
 {
     $REBAR3_TARGET="https://s3.amazonaws.com/rebar3-nightly/rebar3"
     $REBAR3_NIGHTLY=" (from nightly build)"
 }
-Invoke-WebRequest "$REBAR3_TARGET" -OutFile "$FILE_OUTPUT"
+Invoke-WebRequest "${REBAR3_TARGET}" -OutFile "${FILE_OUTPUT}"
 $ProgressPreference="Continue"
-New-Item "$DIR_FOR_BIN/bin" -ItemType Directory | Out-Null
-Move-Item "$FILE_OUTPUT" "$DIR_FOR_BIN/bin"
-Write-Output "& escript.exe $PWD/$DIR_FOR_BIN/bin/$FILE_OUTPUT `$args" | Out-File -FilePath "$FILE_OUTPUT_PS1" -Encoding utf8 -Append
-type $FILE_OUTPUT_PS1
-Move-Item "$FILE_OUTPUT_PS1" "$DIR_FOR_BIN/bin"
-Write-Output "Installed rebar3 version$REBAR3_NIGHTLY follows"
-& "$DIR_FOR_BIN/bin/rebar3" "version" | Write-Output
+New-Item "${DIR_FOR_BIN}/bin" -ItemType Directory | Out-Null
+Move-Item "${FILE_OUTPUT}" "${DIR_FOR_BIN}/bin"
+Write-Output "& escript.exe ${PWD}/${DIR_FOR_BIN}/bin/${FILE_OUTPUT} `${args}" | Out-File -FilePath "${FILE_OUTPUT_PS1}" -Encoding utf8 -Append
+type ${FILE_OUTPUT_PS1}
+Move-Item "${FILE_OUTPUT_PS1}" "${DIR_FOR_BIN}/bin"
+Write-Output "Installed rebar3 version${REBAR3_NIGHTLY} follows"
+& "${DIR_FOR_BIN}/bin/rebar3" "version" | Write-Output
 
 "INSTALL_DIR_FOR_REBAR3=${Env:RUNNER_TEMP}/${DIR_FOR_BIN}" | Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append

--- a/src/install-rebar3.ps1
+++ b/src/install-rebar3.ps1
@@ -26,3 +26,5 @@ type $FILE_OUTPUT_PS1
 Move-Item "$FILE_OUTPUT_PS1" "$DIR_FOR_BIN/bin"
 Write-Output "Installed rebar3 version$REBAR3_NIGHTLY follows"
 & "$DIR_FOR_BIN/bin/rebar3" "version" | Write-Output
+
+"INSTALL_DIR_FOR_REBAR3=${Env:RUNNER_TEMP}/${DIR_FOR_BIN}" | Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append

--- a/src/install-rebar3.sh
+++ b/src/install-rebar3.sh
@@ -21,3 +21,5 @@ chmod +x "${FILE_OUTPUT}"
 mv "${FILE_OUTPUT}" "${DIR_FOR_BIN}/bin"
 echo "Installed rebar3 version$REBAR3_NIGHTLY follows"
 ${DIR_FOR_BIN}/bin/rebar3 version
+
+echo "INSTALL_DIR_FOR_REBAR3=${RUNNER_TEMP}/${DIR_FOR_BIN}" >> "${GITHUB_ENV}"

--- a/src/install-rebar3.sh
+++ b/src/install-rebar3.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-cd "$RUNNER_TEMP"
+cd "${RUNNER_TEMP}"
 
 VSN=${1}
 FILE_INPUT=rebar3
@@ -19,7 +19,7 @@ wget -q -O "${FILE_OUTPUT}" "${REBAR3_TARGET}"
 mkdir -p "${DIR_FOR_BIN}/bin"
 chmod +x "${FILE_OUTPUT}"
 mv "${FILE_OUTPUT}" "${DIR_FOR_BIN}/bin"
-echo "Installed rebar3 version$REBAR3_NIGHTLY follows"
+echo "Installed rebar3 version${REBAR3_NIGHTLY} follows"
 ${DIR_FOR_BIN}/bin/rebar3 version
 
 echo "INSTALL_DIR_FOR_REBAR3=${RUNNER_TEMP}/${DIR_FOR_BIN}" >> "${GITHUB_ENV}"

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -405,6 +405,7 @@ function getRunnerOSVersion() {
     ubuntu18: 'ubuntu-18.04',
     ubuntu20: 'ubuntu-20.04',
     win19: 'windows-2019',
+    win22: 'windows-2022',
   }
   const containerFromEnvImageOS = ImageOSToContainer[process.env.ImageOS]
 


### PR DESCRIPTION
⚠️ don't merge before #91+#92 and the 3rd party licenses are update (lest we have "expected" errors which don't tell the whole story)

This introduces some env. variables to the run, namely the ones identified in the `README.md`:
- `INSTALL_DIR_FOR_ELIXIR`: base folder for Erlang/OTP
- `INSTALL_DIR_FOR_GLEAM`: base folder for Elixir
- `INSTALL_DIR_FOR_OTP`: base folder for Gleam
- `INSTALL_DIR_FOR_REBAR3`: base folder for `rebar3`

and hopefully it closes #89 (still waiting on a comment/test by @samaaron)