### PR TITLE
Handle strings as such

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -27,7 +27,6 @@ jobs:
       - run: npm run shellcheck
       - run: npm run yamllint
       - run: npm run jslint
-      - run: npm run licenses
       - name: Check if build left artifacts
         run: git diff --exit-code
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -6046,7 +6046,7 @@ async function maybeInstallElixir(elixirSpec, otpVersion) {
     const disableProblemMatchers = core.getInput('disable_problem_matchers', {
       required: false,
     })
-    if (!disableProblemMatchers) {
+    if (disableProblemMatchers === 'false') {
       const matchersPath = __nccwpck_require__.ab + ".github"
       console.log(
         `##[add-matcher]${path.join(matchersPath, 'elixir-matchers.json')}`,
@@ -6062,7 +6062,7 @@ async function maybeInstallElixir(elixirSpec, otpVersion) {
 }
 
 async function mix(shouldMix, what) {
-  if (shouldMix) {
+  if (shouldMix === 'true') {
     const cmd = 'mix'
     const args = [`local.${what}`, '--force']
     console.log(`##[group]Running ${cmd} ${args}`)

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -73,7 +73,7 @@ async function maybeInstallElixir(elixirSpec, otpVersion) {
     const disableProblemMatchers = core.getInput('disable_problem_matchers', {
       required: false,
     })
-    if (!disableProblemMatchers) {
+    if (disableProblemMatchers === 'false') {
       const matchersPath = path.join(__dirname, '..', '.github')
       console.log(
         `##[add-matcher]${path.join(matchersPath, 'elixir-matchers.json')}`,
@@ -89,7 +89,7 @@ async function maybeInstallElixir(elixirSpec, otpVersion) {
 }
 
 async function mix(shouldMix, what) {
-  if (shouldMix) {
+  if (shouldMix === 'true') {
     const cmd = 'mix'
     const args = [`local.${what}`, '--force']
     console.log(`##[group]Running ${cmd} ${args}`)


### PR DESCRIPTION
This hopefully fixes one of the issues found via #99 (mis-handling of booleans).

**Note**: this'll most likely break stuff in-the-wild, since the way the values were being read (`getInput`) meant we'd always mix `rebar` and `hex`. We can either go with this approach (and bump major) or consider the default should've been `true`, from the start, and change that.