### PR TITLE
Fix wrong environment variable descriptions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,9 @@ jobs:
 Base installation folders (useful for e.g. fetching headers for NIFs) are available in the following
 environment variables:
 
-- `INSTALL_DIR_FOR_ELIXIR`: base folder for Erlang/OTP
-- `INSTALL_DIR_FOR_GLEAM`: base folder for Elixir
-- `INSTALL_DIR_FOR_OTP`: base folder for Gleam
+- `INSTALL_DIR_FOR_OTP`: base folder for Erlang/OTP
+- `INSTALL_DIR_FOR_ELIXIR`: base folder for Elixir
+- `INSTALL_DIR_FOR_GLEAM`: base folder for Gleam
 - `INSTALL_DIR_FOR_REBAR3`: base folder for `rebar3`
 
 ## Elixir Problem Matchers


### PR DESCRIPTION
Fixes typos in the description of environment variables in the project's README.md file.