### PR TITLE
Fix mispaste in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ workflow by:
 - optionally, installing [`hex`](https://hex.pm/)
 - optionally, having
   [problem matchers](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md) show
-  warnings and errors on pull requestsotp-version: false)
+  warnings and errors on pull requests
 
 **Note**: currently, this action only supports Actions' `ubuntu-` and `windows-` runtimes.
 


### PR DESCRIPTION
I seem to have introduced it in https://github.com/erlef/setup-beam/pull/81/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21 so it's only fair (and less embarrassing for me) that I fix it :)