### PR TITLE
Wrong Erlang/OTP version `maint-x` matched when requesting `x`

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6191,12 +6191,12 @@ async function maybeInstallRebar3(rebar3Spec) {
 
 async function getOTPVersion(otpSpec0, osVersion) {
   const otpVersions = await getOTPVersions(osVersion)
-  const otpSpec = otpSpec0.match(/^(OTP-)?([^ ]+)/)
+  const otpSpec = otpSpec0.match(/^(OTP-|maint-)?([^ ]+)/)
   let otpVersion
   if (otpSpec[1] && !isStrictVersion()) {
     throw new Error(
       `Requested Erlang/OTP version (${otpSpec0}) ` +
-        "should not contain 'OTP-'",
+        "should not contain 'OTP-, or maint-'",
     )
   }
   if (otpSpec) {
@@ -6310,7 +6310,7 @@ async function getOTPVersions(osVersion) {
       .trim()
       .split('\n')
       .forEach((line) => {
-        const otpMatch = line.match(/^(OTP-)?([^ ]+)/)
+        const otpMatch = line.match(/^(OTP-|maint-)?([^ ]+)/)
         const otpVersion = otpMatch[2]
         otpVersions.set(otpVersion, otpMatch[0]) // we keep the original for later reference
       })

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -139,12 +139,12 @@ async function maybeInstallRebar3(rebar3Spec) {
 
 async function getOTPVersion(otpSpec0, osVersion) {
   const otpVersions = await getOTPVersions(osVersion)
-  const otpSpec = otpSpec0.match(/^(OTP-)?([^ ]+)/)
+  const otpSpec = otpSpec0.match(/^(OTP-|maint-)?([^ ]+)/)
   let otpVersion
   if (otpSpec[1] && !isStrictVersion()) {
     throw new Error(
       `Requested Erlang/OTP version (${otpSpec0}) ` +
-        "should not contain 'OTP-'",
+        "should not contain 'OTP-, or maint-'",
     )
   }
   if (otpSpec) {
@@ -258,7 +258,7 @@ async function getOTPVersions(osVersion) {
       .trim()
       .split('\n')
       .forEach((line) => {
-        const otpMatch = line.match(/^(OTP-)?([^ ]+)/)
+        const otpMatch = line.match(/^(OTP-|maint-)?([^ ]+)/)
         const otpVersion = otpMatch[2]
         otpVersions.set(otpVersion, otpMatch[0]) // we keep the original for later reference
       })


### PR DESCRIPTION
Don't take `maint-` -prefixed versions into account unless they're asked for it specifically.
At the same time, while fetching versions, make sure we identify them better so that `25` does not end up pulling `maint-25` instead of `OTP-25.0`, as it should.

Closes #120.