### PR TITLE
Crash on invalid Elixir+OTP combo

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -116,6 +116,7 @@ jobs:
           - elixir-version: 'master'
             otp-version: '25'
             os:  'ubuntu-20.04'
+            version-type: 'strict'
           - gleam-version: 'nightly'
             otp-version: '24'
           - gleam-version: '0.23'

--- a/__tests__/setup-beam.test.js
+++ b/__tests__/setup-beam.test.js
@@ -171,8 +171,8 @@ async function testElixirVersions() {
   let otpVersion
 
   spec = '1.1.x'
-  otpVersion = 'OTP-23'
-  expected = 'v1.1.1'
+  otpVersion = 'OTP-17'
+  expected = 'v1.1.1-otp-17'
   got = await setupBeam.getElixirVersion(spec, otpVersion)
   assert.deepStrictEqual(got, expected)
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -7358,9 +7358,11 @@ async function getElixirVersion(exSpec0, otpVersion) {
         `Using Elixir ${elixirVersion} (built for OTP ${otpVersionMajor})`,
       )
     } else {
-      // ... and it's not available: fallback to the 'generic' version (v1.4.5 only).
-      elixirVersionWithOTP = elixirVersion
-      core.info(`Using Elixir ${elixirVersion}`)
+      // ... and it's not available: exit with exception
+      throw new Error(
+        `Requested Elixir / Erlang/OTP version (${exSpec0} / ${otpVersion}) not ` +
+          'found in version list (did you check Compatibility between Elixir and Erlang/OTP?)',
+      )
     }
   } else {
     throw new Error(

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -188,9 +188,11 @@ async function getElixirVersion(exSpec0, otpVersion) {
         `Using Elixir ${elixirVersion} (built for OTP ${otpVersionMajor})`,
       )
     } else {
-      // ... and it's not available: fallback to the 'generic' version (v1.4.5 only).
-      elixirVersionWithOTP = elixirVersion
-      core.info(`Using Elixir ${elixirVersion}`)
+      // ... and it's not available: exit with exception
+      throw new Error(
+        `Requested Elixir / Erlang/OTP version (${exSpec0} / ${otpVersion}) not ` +
+          'found in version list (did you check Compatibility between Elixir and Erlang/OTP?)',
+      )
     }
   } else {
     throw new Error(


### PR DESCRIPTION
Closes #131.

**Edit**: this also fixes some tests that started failing due to our new pre-conditions.