### PR TITLE
Install OTP on Windows to a local directory

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7173,7 +7173,6 @@ const { exec } = __nccwpck_require__(1514)
 const path = __nccwpck_require__(1017)
 const semver = __nccwpck_require__(1383)
 const https = __nccwpck_require__(5687)
-const fs = __nccwpck_require__(7147)
 const installer = __nccwpck_require__(2127)
 
 main().catch((err) => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -7218,15 +7218,7 @@ async function installOTP(otpSpec, osVersion) {
   )
   await installer.installOTP(osVersion, otpVersion)
   core.setOutput('otp-version', otpVersion)
-  if (process.platform === 'linux') {
-    core.addPath(`${process.env.RUNNER_TEMP}/.setup-beam/otp/bin`)
-  } else if (process.platform === 'win32') {
-    const otpPath = fs.readFileSync(`${process.env.RUNNER_TEMP}/otp_path.txt`, {
-      encoding: 'utf8',
-      flag: 'r',
-    })
-    core.addPath(otpPath)
-  }
+  core.addPath(`${process.env.RUNNER_TEMP}/.setup-beam/otp/bin`)
   console.log('##[endgroup]')
 
   return otpVersion

--- a/dist/install-otp.ps1
+++ b/dist/install-otp.ps1
@@ -5,18 +5,13 @@ $ErrorActionPreference="Stop"
 Set-Location ${Env:RUNNER_TEMP}
 
 $FILE_OUTPUT="otp.exe"
-$DIR_FOR_BIN=".setup-beam/otp"
+$ERL_ROOT = "${Env:RUNNER_TEMP}\.setup-beam\otp"
 
 $ProgressPreference="SilentlyContinue"
 Invoke-WebRequest "https://github.com/erlang/otp/releases/download/OTP-${VSN}/otp_win64_${VSN}.exe" -OutFile "${FILE_OUTPUT}"
 $ProgressPreference="Continue"
-New-Item "${DIR_FOR_BIN}" -ItemType Directory | Out-Null
-Move-Item "${FILE_OUTPUT}" "${DIR_FOR_BIN}"
-Start-Process "./${DIR_FOR_BIN}/${FILE_OUTPUT}" /S -Wait
-$ErlExec = Get-ChildItem -Path "C:/Program Files/" -Recurse -Depth 2 -Filter 'erl.exe' -Name | ForEach-Object { Write-Output "C:/Program Files/$_" }
-$ErlPath = Split-Path -Path "${ErlExec}"
-Write-Output "${ErlPath}" | Out-File -FilePath otp_path.txt -Encoding utf8 -NoNewline
+Start-Process "${FILE_OUTPUT}" "/S /D=${ERL_ROOT}" -Wait
 Write-Output "Installed Erlang/OTP version follows"
-& "${ErlPath}/erl.exe" "+V" | Write-Output
+& "${ERL_ROOT}/bin/erl.exe" "+V" | Write-Output
 
-"INSTALL_DIR_FOR_OTP="+(Get-Item ${ErlPath}).parent.FullName | Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append
+"INSTALL_DIR_FOR_OTP=" + ${ERL_ROOT}

--- a/dist/install-otp.sh
+++ b/dist/install-otp.sh
@@ -17,4 +17,4 @@ tar zxf "${FILE_OUTPUT}" -C "${DIR_FOR_BIN}" --strip-components=1
 echo "Installed Erlang/OTP version follows"
 ${DIR_FOR_BIN}/bin/erl -version
 
-echo "INSTALL_DIR_FOR_OTP=${RUNNER_TEMP}/${DIR_FOR_BIN}" >> "${GITHUB_ENV}"
+echo "INSTALL_DIR_FOR_OTP=${RUNNER_TEMP}/${DIR_FOR_BIN}"

--- a/src/install-otp.ps1
+++ b/src/install-otp.ps1
@@ -5,18 +5,13 @@ $ErrorActionPreference="Stop"
 Set-Location ${Env:RUNNER_TEMP}
 
 $FILE_OUTPUT="otp.exe"
-$DIR_FOR_BIN=".setup-beam/otp"
+$ERL_ROOT = "${Env:RUNNER_TEMP}\.setup-beam\otp"
 
 $ProgressPreference="SilentlyContinue"
 Invoke-WebRequest "https://github.com/erlang/otp/releases/download/OTP-${VSN}/otp_win64_${VSN}.exe" -OutFile "${FILE_OUTPUT}"
 $ProgressPreference="Continue"
-New-Item "${DIR_FOR_BIN}" -ItemType Directory | Out-Null
-Move-Item "${FILE_OUTPUT}" "${DIR_FOR_BIN}"
-Start-Process "./${DIR_FOR_BIN}/${FILE_OUTPUT}" /S -Wait
-$ErlExec = Get-ChildItem -Path "C:/Program Files/" -Recurse -Depth 2 -Filter 'erl.exe' -Name | ForEach-Object { Write-Output "C:/Program Files/$_" }
-$ErlPath = Split-Path -Path "${ErlExec}"
-Write-Output "${ErlPath}" | Out-File -FilePath otp_path.txt -Encoding utf8 -NoNewline
+Start-Process "${FILE_OUTPUT}" "/S /D=${ERL_ROOT}" -Wait
 Write-Output "Installed Erlang/OTP version follows"
-& "${ErlPath}/erl.exe" "+V" | Write-Output
+& "${ERL_ROOT}/bin/erl.exe" "+V" | Write-Output
 
-"INSTALL_DIR_FOR_OTP="+(Get-Item ${ErlPath}).parent.FullName | Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append
+"INSTALL_DIR_FOR_OTP=" + ${ERL_ROOT}

--- a/src/install-otp.sh
+++ b/src/install-otp.sh
@@ -17,4 +17,4 @@ tar zxf "${FILE_OUTPUT}" -C "${DIR_FOR_BIN}" --strip-components=1
 echo "Installed Erlang/OTP version follows"
 ${DIR_FOR_BIN}/bin/erl -version
 
-echo "INSTALL_DIR_FOR_OTP=${RUNNER_TEMP}/${DIR_FOR_BIN}" >> "${GITHUB_ENV}"
+echo "INSTALL_DIR_FOR_OTP=${RUNNER_TEMP}/${DIR_FOR_BIN}"

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -3,7 +3,6 @@ const { exec } = require('@actions/exec')
 const path = require('path')
 const semver = require('semver')
 const https = require('https')
-const fs = require('fs')
 const installer = require('./installer')
 
 main().catch((err) => {

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -48,15 +48,7 @@ async function installOTP(otpSpec, osVersion) {
   )
   await installer.installOTP(osVersion, otpVersion)
   core.setOutput('otp-version', otpVersion)
-  if (process.platform === 'linux') {
-    core.addPath(`${process.env.RUNNER_TEMP}/.setup-beam/otp/bin`)
-  } else if (process.platform === 'win32') {
-    const otpPath = fs.readFileSync(`${process.env.RUNNER_TEMP}/otp_path.txt`, {
-      encoding: 'utf8',
-      flag: 'r',
-    })
-    core.addPath(otpPath)
-  }
+  core.addPath(`${process.env.RUNNER_TEMP}/.setup-beam/otp/bin`)
   console.log('##[endgroup]')
 
   return otpVersion


### PR DESCRIPTION
It is especially useful not to install things globally on self-hosted runner as these may not be running in isolation.

By installing OTP into a known location we could remove the code that was checking where exactly it was installed.

This PR also removes the `echo $INSTALL_DIR_FOR_OTP >> $GITHUB_ENV` (and the PowerShell equivalent) as it never worked. The variable name should have been `$GITHUB_PATH`, not `$GITHUB_ENV`. Again, no longer necessary as we install OTP to a known location.
