### PR TITLE
Ease Elixir escripts execution by adding ${HOME}/.mix/escripts to path

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -134,6 +134,11 @@ jobs:
             otp-version: '24'
             os: 'ubuntu-latest'
             disable_problem_matchers: true
+          - elixir-version: 'v1.13'
+            otp-version: '24'
+            escript_packages: 'hex protobuf'
+            escript_script: 'protoc-gen-elixir --version'
+            os: 'ubuntu-latest'
     steps:
       - uses: actions/checkout@v3
       - name: Use erlef/setup-beam
@@ -184,6 +189,11 @@ jobs:
           cd test-projects/gleam_gleam
           gleam test
         if: ${{ matrix.combo.gleam-version && matrix.combo.otp-version && !matrix.combo.rebar3-version }}
+      - name: Run escript
+        run: |
+          mix escript.install ${{matrix.combo.escript_packages}}
+          ${{matrix.combo.escript_script}}
+        if: ${{matrix.combo.escript_packages && matrix.combo.escript_script}}
   environment_variables:
     name: Environment variables
     runs-on: ${{matrix.combo.os}}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -191,7 +191,7 @@ jobs:
         if: ${{ matrix.combo.gleam-version && matrix.combo.otp-version && !matrix.combo.rebar3-version }}
       - name: Run escript
         run: |
-          mix escript.install ${{matrix.combo.escript_packages}}
+          mix escript.install --force ${{matrix.combo.escript_packages}}
           ${{matrix.combo.escript_script}}
         if: ${{matrix.combo.escript_packages && matrix.combo.escript_script}}
   environment_variables:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -89,7 +89,7 @@ jobs:
         if: ${{matrix.combo.rebar3-version}}
       - name: Run escript
         run: |
-          mix escript.install ${{matrix.combo.escript_packages}}
+          mix escript.install --force ${{matrix.combo.escript_packages}}
           ${{matrix.combo.escript_script}}
         if: ${{matrix.combo.escript_packages && matrix.combo.escript_script}}
   environment_variables:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -45,6 +45,11 @@ jobs:
             otp-version: '24'
             rebar3-version: '3.16'
             os: 'windows-latest'
+          - elixir-version: 'v1.13'
+            otp-version: '24'
+            escript_packages: 'hex protobuf'
+            escript_script: 'protoc-gen-elixir --version'
+            os: 'windows-latest'
     steps:
       - uses: actions/checkout@v3
       - name: Use erlef/setup-beam
@@ -82,6 +87,11 @@ jobs:
           cd test-projects/erlang_rebar3
           rebar3 ct
         if: ${{matrix.combo.rebar3-version}}
+      - name: Run escript
+        run: |
+          mix escript.install ${{matrix.combo.escript_packages}}
+          ${{matrix.combo.escript_script}}
+        if: ${{matrix.combo.escript_packages && matrix.combo.escript_script}}
   environment_variables:
     name: Environment variables
     runs-on: ${{matrix.combo.os}}

--- a/dist/index.js
+++ b/dist/index.js
@@ -7263,6 +7263,7 @@ async function maybeInstallElixir(elixirSpec, otpVersion) {
         `##[add-matcher]${path.join(matchersPath, 'elixir-matchers.json')}`,
       )
     }
+    core.addPath(`${process.env.HOME}/.mix/escripts`)
     core.addPath(`${process.env.RUNNER_TEMP}/.setup-beam/elixir/bin`)
     console.log('##[endgroup]')
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -7193,6 +7193,7 @@ module.exports = {
 
 const core = __nccwpck_require__(2186)
 const { exec } = __nccwpck_require__(1514)
+const os = __nccwpck_require__(2037)
 const path = __nccwpck_require__(1017)
 const semver = __nccwpck_require__(1383)
 const https = __nccwpck_require__(5687)
@@ -7263,7 +7264,7 @@ async function maybeInstallElixir(elixirSpec, otpVersion) {
         `##[add-matcher]${path.join(matchersPath, 'elixir-matchers.json')}`,
       )
     }
-    core.addPath(`${process.env.HOME}/.mix/escripts`)
+    core.addPath(`${os.homedir()}/.mix/escripts`)
     core.addPath(`${process.env.RUNNER_TEMP}/.setup-beam/elixir/bin`)
     console.log('##[endgroup]')
 

--- a/dist/install-elixir.ps1
+++ b/dist/install-elixir.ps1
@@ -18,4 +18,7 @@ $ProgressPreference="Continue"
 Write-Output "Installed Elixir version follows"
 & "${DIR_FOR_BIN}/bin/elixir" "-v" | Write-Output
 
+$ProgressPreference="Continue"
+New-Item "%UserProfile%\.mix\escripts" -ItemType Directory | Out-Null
+
 "INSTALL_DIR_FOR_ELIXIR=${Env:RUNNER_TEMP}/${DIR_FOR_BIN}" | Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append

--- a/dist/install-elixir.ps1
+++ b/dist/install-elixir.ps1
@@ -19,6 +19,6 @@ Write-Output "Installed Elixir version follows"
 & "${DIR_FOR_BIN}/bin/elixir" "-v" | Write-Output
 
 $ProgressPreference="Continue"
-New-Item "%UserProfile%\.mix\escripts" -ItemType Directory | Out-Null
+New-Item "%UserProfile%/.mix/escripts" -ItemType Directory | Out-Null
 
 "INSTALL_DIR_FOR_ELIXIR=${Env:RUNNER_TEMP}/${DIR_FOR_BIN}" | Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append

--- a/dist/install-elixir.sh
+++ b/dist/install-elixir.sh
@@ -15,4 +15,6 @@ unzip -q -o -d "${DIR_FOR_BIN}" "${FILE_OUTPUT}"
 echo "Installed Elixir version follows"
 ${DIR_FOR_BIN}/bin/elixir -v
 
+mkdir -p "${HOME}/.mix/escripts"
+
 echo "INSTALL_DIR_FOR_ELIXIR=${RUNNER_TEMP}/${DIR_FOR_BIN}" >> "${GITHUB_ENV}"

--- a/src/install-elixir.ps1
+++ b/src/install-elixir.ps1
@@ -18,4 +18,7 @@ $ProgressPreference="Continue"
 Write-Output "Installed Elixir version follows"
 & "${DIR_FOR_BIN}/bin/elixir" "-v" | Write-Output
 
+$ProgressPreference="Continue"
+New-Item "%UserProfile%\.mix\escripts" -ItemType Directory | Out-Null
+
 "INSTALL_DIR_FOR_ELIXIR=${Env:RUNNER_TEMP}/${DIR_FOR_BIN}" | Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append

--- a/src/install-elixir.ps1
+++ b/src/install-elixir.ps1
@@ -19,6 +19,6 @@ Write-Output "Installed Elixir version follows"
 & "${DIR_FOR_BIN}/bin/elixir" "-v" | Write-Output
 
 $ProgressPreference="Continue"
-New-Item "%UserProfile%\.mix\escripts" -ItemType Directory | Out-Null
+New-Item "%UserProfile%/.mix/escripts" -ItemType Directory | Out-Null
 
 "INSTALL_DIR_FOR_ELIXIR=${Env:RUNNER_TEMP}/${DIR_FOR_BIN}" | Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append

--- a/src/install-elixir.sh
+++ b/src/install-elixir.sh
@@ -15,4 +15,6 @@ unzip -q -o -d "${DIR_FOR_BIN}" "${FILE_OUTPUT}"
 echo "Installed Elixir version follows"
 ${DIR_FOR_BIN}/bin/elixir -v
 
+mkdir -p "${HOME}/.mix/escripts"
+
 echo "INSTALL_DIR_FOR_ELIXIR=${RUNNER_TEMP}/${DIR_FOR_BIN}" >> "${GITHUB_ENV}"

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -1,5 +1,6 @@
 const core = require('@actions/core')
 const { exec } = require('@actions/exec')
+const os = require('os')
 const path = require('path')
 const semver = require('semver')
 const https = require('https')
@@ -70,7 +71,7 @@ async function maybeInstallElixir(elixirSpec, otpVersion) {
         `##[add-matcher]${path.join(matchersPath, 'elixir-matchers.json')}`,
       )
     }
-    core.addPath(`${process.env.HOME}/.mix/escripts`)
+    core.addPath(`${os.homedir()}/.mix/escripts`)
     core.addPath(`${process.env.RUNNER_TEMP}/.setup-beam/elixir/bin`)
     console.log('##[endgroup]')
 

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -70,6 +70,7 @@ async function maybeInstallElixir(elixirSpec, otpVersion) {
         `##[add-matcher]${path.join(matchersPath, 'elixir-matchers.json')}`,
       )
     }
+    core.addPath(`${process.env.HOME}/.mix/escripts`)
     core.addPath(`${process.env.RUNNER_TEMP}/.setup-beam/elixir/bin`)
     console.log('##[endgroup]')
 


### PR DESCRIPTION
This adds the mix escripts folder to `PATH`, allowing you to run `mix escript.install hex protobuf --force` and have access to the protobuf generator right away. Making life simpler.

I'm having this as a WIP because I don't program in windows and need to confirm this actually works as intended.