### PR TITLE
Ease consumption by means of .tool-versions

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -40,6 +40,11 @@ jobs:
           node-version: '14'
       - run: npm ci
       - run: npm test
+      - name: .tool-versions test
+        id: setup-beam
+        uses: ./
+        with:
+          version-file: '__tests__/.tool-versions'
 
   unit_tests_windows:
     name: Unit tests (Windows)
@@ -51,3 +56,8 @@ jobs:
           node-version: '14'
       - run: npm install --production
       - run: npm test
+      - name: .tool-versions test
+        id: setup-beam
+        uses: ./
+        with:
+          version-file: '__tests__/.tool-versions'

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -57,9 +57,3 @@ jobs:
           node-version: '14'
       - run: npm install --production
       - run: npm test
-      - name: .tool-versions test
-        id: setup-beam
-        uses: ./
-        with:
-          version-file: __tests__/.tool-versions
-          version-type: strict

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -44,7 +44,8 @@ jobs:
         id: setup-beam
         uses: ./
         with:
-          version-file: '__tests__/.tool-versions'
+          version-file: __tests__/.tool-versions
+          version-type: strict
 
   unit_tests_windows:
     name: Unit tests (Windows)
@@ -60,4 +61,5 @@ jobs:
         id: setup-beam
         uses: ./
         with:
-          version-file: '__tests__/.tool-versions'
+          version-file: __tests__/.tool-versions
+          version-type: strict

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/**
 dist/.github/workflows
+__tests__/.tool-versions

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ workflow by:
 - optionally, installing [Gleam](https://gleam.run/)
 - optionally, installing [`rebar3`](https://www.rebar3.org/)
 - optionally, installing [`hex`](https://hex.pm/)
+- optionally, opting for strict or loose version matching
 - optionally, having
   [problem matchers](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md) show
   warnings and errors on pull requests
+- optionally, using a version file (as explained in "Version file", below), to identify versions
 
 **Note**: currently, this action only supports Actions' `ubuntu-` and `windows-` runtimes.
 
@@ -85,6 +87,31 @@ jobs:
       - uses: erlef/setup-beam@v1
         ...
 ```
+
+### Version file
+
+A version file is specified via input `version-file` (e.g.`.tool-versions`). This
+allows not having to use YML input for versions, though the action does check (and
+will exit with error) if both inputs are set.
+
+**Note**: if you're using a version file, option `version-type` is checked to be `strict`,
+and will make the action exit with error otherwise.
+
+The following version file formats are supported:
+
+- `.tool-versions`, as specified by [asdf: Configuration](https://asdf-vm.com/manage/configuration.html)
+
+Supported version elements are the same as the ones defined for the YML portion of the action,
+with the following correspondence.
+
+#### `.tool-versions` format
+
+| YML              | `.tool-versions` |
+|-                 |-
+| `otp-version`    | `erlang`
+| `elixir-version` | `elixir`
+| `gleam-version`  | `gleam`
+| `rebar3-version` | `rebar`
 
 ### Example (Erlang/OTP + Elixir, on Ubuntu)
 

--- a/action.yml
+++ b/action.yml
@@ -31,8 +31,12 @@ inputs:
       to guess versions based on semver rules
     default: loose
   disable_problem_matchers:
-    description: whether to have the problem matchers present in the results (or not)
+    description: whether to have the problem matchers present in the results
+      (or not)
     default: false
+  version-file:
+    description: a versions file (e.g. as used by `asdf`), which defines inputs
+    default: ''
 outputs:
   elixir-version:
     description: Exact version of Elixir that was installed

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,6 @@ inputs:
   otp-version:
     description: Version range or exact version of Erlang/OTP to use,
       or false when installing only Gleam without OTP
-    required: true
   elixir-version:
     description: Version range or exact version of Elixir to use
   gleam-version:

--- a/dist/index.js
+++ b/dist/index.js
@@ -7207,7 +7207,7 @@ async function main() {
   installer.checkPlatform()
 
   const versionFilePath = getInput('version-file', false)
-  let versions = {}
+  let versions
   if (versionFilePath) {
     if (!isStrictVersion()) {
       throw new Error(

--- a/dist/index.js
+++ b/dist/index.js
@@ -7668,8 +7668,8 @@ function getInput(inputName, required, alternativeName, alternatives) {
   if (input && alternativeValue) {
     throw new Error(
       `Found input ${inputName}=${input} (from the YML) \
-       alongside ${alternativeName}=${alternativeValue} \
-       (from the version file). You must choose one or the other.`,
+alongside ${alternativeName}=${alternativeValue} \
+(from the version file). You must choose one or the other.`,
     )
   } else if (!input) {
     input = alternativeValue

--- a/dist/index.js
+++ b/dist/index.js
@@ -7665,10 +7665,10 @@ function isVersion(v) {
 }
 
 function getInput(inputName, required, alternativeName, alternativeValue) {
-  // We can't have both input and alternativeValue set
   let input = core.getInput(inputName, {
     required: alternativeValue ? false : required,
   })
+  // We can't have both input and alternativeValue set
   if (input && alternativeValue) {
     throw new Error(
       `Found input ${inputName}=${input} (from the YML) \
@@ -7698,7 +7698,7 @@ function parseVersionFile(versionFilePath0) {
     const appVersion = line.match(/^([^ ]+)[ ]+([^ #]+)/)
     if (appVersion) {
       const app = appVersion[1]
-      if (['erlang', 'elixir', 'gleam', 'rebar3'].includes(app)) {
+      if (['erlang', 'elixir', 'gleam', 'rebar'].includes(app)) {
         const [, , version] = appVersion
         console.log(`Consuming ${app} at version ${version}`)
         appVersions.set(app, version)

--- a/dist/index.js
+++ b/dist/index.js
@@ -7690,6 +7690,9 @@ function parseVersionFile(versionFilePath0) {
   console.log(`##[group]Parsing version file at ${versionFilePath0}`)
   const appVersions = new Map()
   const versions = fs.readFileSync(versionFilePath, 'utf8')
+  // For the time being we parse .tool-versions
+  // If we ever start parsing something else, this should
+  // become default in a new option named e.g. version-file-type
   versions.split('\n').forEach((line) => {
     const appVersion = line.match(/^([^ ]+)[ ]+([^ #]+)/)
     if (appVersion) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -7196,6 +7196,7 @@ const { exec } = __nccwpck_require__(1514)
 const path = __nccwpck_require__(1017)
 const semver = __nccwpck_require__(1383)
 const https = __nccwpck_require__(5687)
+const fs = __nccwpck_require__(7147)
 const installer = __nccwpck_require__(2127)
 
 main().catch((err) => {
@@ -7205,24 +7206,36 @@ main().catch((err) => {
 async function main() {
   installer.checkPlatform()
 
+  const versionFilePath = getInput('version-file', false)
+  let versions = {}
+  if (versionFilePath) {
+    if (!isStrictVersion()) {
+      throw new Error(
+        "you have to set version-type=strict if you're using version-file",
+      )
+    }
+    versions = parseVersionFile(versionFilePath)
+  }
+
   const osVersion = getRunnerOSVersion()
-  const otpSpec = core.getInput('otp-version', { required: true })
-  const elixirSpec = core.getInput('elixir-version', { required: false })
-  const gleamSpec = core.getInput('gleam-version', { required: false })
-  const rebar3Spec = core.getInput('rebar3-version', { required: false })
+  const otpSpec = getInput('otp-version', true, 'erlang', versions.erlang)
+  const elixirSpec = getInput(
+    'elixir-version',
+    false,
+    'elixir',
+    versions.elixir,
+  )
+  const gleamSpec = getInput('gleam-version', false, 'gleam', versions.gleam)
+  const rebar3Spec = getInput('rebar3-version', false, 'rebar', versions.rebar)
 
   if (otpSpec !== 'false') {
     await installOTP(otpSpec, osVersion)
     const elixirInstalled = await maybeInstallElixir(elixirSpec, otpSpec)
 
     if (elixirInstalled === true) {
-      const shouldMixRebar = core.getInput('install-rebar', {
-        required: false,
-      })
+      const shouldMixRebar = getInput('install-rebar', false)
       await mix(shouldMixRebar, 'rebar')
-      const shouldMixHex = core.getInput('install-hex', {
-        required: false,
-      })
+      const shouldMixHex = getInput('install-hex', false)
       await mix(shouldMixHex, 'hex')
     }
   } else if (!gleamSpec) {
@@ -7254,9 +7267,7 @@ async function maybeInstallElixir(elixirSpec, otpVersion) {
     console.log(`##[group]Installing Elixir ${elixirVersion}`)
     await installer.installElixir(elixirVersion)
     core.setOutput('elixir-version', elixirVersion)
-    const disableProblemMatchers = core.getInput('disable_problem_matchers', {
-      required: false,
-    })
+    const disableProblemMatchers = getInput('disable_problem_matchers', false)
     if (disableProblemMatchers === 'false') {
       const matchersPath = __nccwpck_require__.ab + ".github"
       console.log(
@@ -7503,7 +7514,7 @@ async function getRebar3Versions() {
 }
 
 function isStrictVersion() {
-  return core.getInput('version-type', { required: false }) === 'strict'
+  return getInput('version-type', false) === 'strict'
 }
 
 function getVersionFromSpec(spec, versions, maybePrependWithV0) {
@@ -7653,12 +7664,64 @@ function isVersion(v) {
   return /^v?\d+/.test(v)
 }
 
+function getInput(inputName, required, alternativeName, alternativeValue) {
+  // We can't have both input and alternativeValue set
+  let input = core.getInput(inputName, {
+    required: alternativeValue ? false : required,
+  })
+  if (input && alternativeValue) {
+    throw new Error(
+      `Found input ${inputName}=${input} (from the YML) \
+       alongside ${alternativeName}=${alternativeValue} \
+       (from the version file). You must choose one or the other.`,
+    )
+  } else if (!input) {
+    input = alternativeValue
+  }
+  return input
+}
+
+function parseVersionFile(versionFilePath0) {
+  const versionFilePath = path.join(
+    process.env.GITHUB_WORKSPACE,
+    versionFilePath0,
+  )
+  if (!fs.existsSync(versionFilePath)) {
+    throw new Error(
+      `The specified version file, ${versionFilePath0}, does not exist`,
+    )
+  }
+  console.log(`##[group]Parsing version file at ${versionFilePath0}`)
+  const appVersions = new Map()
+  const versions = fs.readFileSync(versionFilePath, 'utf8')
+  versions.split('\n').forEach((line) => {
+    const appVersion = line.match(/^([^ ]+)[ ]+([^ #]+)/)
+    if (appVersion) {
+      const app = appVersion[1]
+      if (['erlang', 'elixir', 'gleam', 'rebar3'].includes(app)) {
+        const [, , version] = appVersion
+        console.log(`Consuming ${app} at version ${version}`)
+        appVersions.set(app, version)
+      }
+    }
+  })
+  if (!appVersions.size) {
+    console.log('There was apparently nothing to consume')
+  } else {
+    console.log('... done!')
+  }
+  console.log('##[endgroup]')
+
+  return appVersions
+}
+
 module.exports = {
   getOTPVersion,
   getElixirVersion,
   getGleamVersion,
   getRebar3Version,
   getVersionFromSpec,
+  parseVersionFile,
 }
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -7218,15 +7218,10 @@ async function main() {
   }
 
   const osVersion = getRunnerOSVersion()
-  const otpSpec = getInput('otp-version', true, 'erlang', versions.erlang)
-  const elixirSpec = getInput(
-    'elixir-version',
-    false,
-    'elixir',
-    versions.elixir,
-  )
-  const gleamSpec = getInput('gleam-version', false, 'gleam', versions.gleam)
-  const rebar3Spec = getInput('rebar3-version', false, 'rebar', versions.rebar)
+  const otpSpec = getInput('otp-version', true, 'erlang', versions)
+  const elixirSpec = getInput('elixir-version', false, 'elixir', versions)
+  const gleamSpec = getInput('gleam-version', false, 'gleam', versions)
+  const rebar3Spec = getInput('rebar3-version', false, 'rebar', versions)
 
   if (otpSpec !== 'false') {
     await installOTP(otpSpec, osVersion)
@@ -7664,7 +7659,8 @@ function isVersion(v) {
   return /^v?\d+/.test(v)
 }
 
-function getInput(inputName, required, alternativeName, alternativeValue) {
+function getInput(inputName, required, alternativeName, alternatives) {
+  const alternativeValue = (alternatives || new Map()).get(alternativeName)
   let input = core.getInput(inputName, {
     required: alternativeValue ? false : required,
   })

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -14,7 +14,7 @@ async function main() {
   installer.checkPlatform()
 
   const versionFilePath = getInput('version-file', false)
-  let versions = {}
+  let versions
   if (versionFilePath) {
     if (!isStrictVersion()) {
       throw new Error(

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -505,7 +505,7 @@ function parseVersionFile(versionFilePath0) {
     const appVersion = line.match(/^([^ ]+)[ ]+([^ #]+)/)
     if (appVersion) {
       const app = appVersion[1]
-      if (['erlang', 'elixir', 'gleam', 'rebar3'].includes(app)) {
+      if (['erlang', 'elixir', 'gleam', 'rebar'].includes(app)) {
         const [, , version] = appVersion
         console.log(`Consuming ${app} at version ${version}`)
         appVersions.set(app, version)

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -25,15 +25,10 @@ async function main() {
   }
 
   const osVersion = getRunnerOSVersion()
-  const otpSpec = getInput('otp-version', true, 'erlang', versions.erlang)
-  const elixirSpec = getInput(
-    'elixir-version',
-    false,
-    'elixir',
-    versions.elixir,
-  )
-  const gleamSpec = getInput('gleam-version', false, 'gleam', versions.gleam)
-  const rebar3Spec = getInput('rebar3-version', false, 'rebar', versions.rebar)
+  const otpSpec = getInput('otp-version', true, 'erlang', versions)
+  const elixirSpec = getInput('elixir-version', false, 'elixir', versions)
+  const gleamSpec = getInput('gleam-version', false, 'gleam', versions)
+  const rebar3Spec = getInput('rebar3-version', false, 'rebar', versions)
 
   if (otpSpec !== 'false') {
     await installOTP(otpSpec, osVersion)
@@ -471,7 +466,8 @@ function isVersion(v) {
   return /^v?\d+/.test(v)
 }
 
-function getInput(inputName, required, alternativeName, alternativeValue) {
+function getInput(inputName, required, alternativeName, alternatives) {
+  const alternativeValue = (alternatives || new Map()).get(alternativeName)
   let input = core.getInput(inputName, {
     required: alternativeValue ? false : required,
   })

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -472,10 +472,10 @@ function isVersion(v) {
 }
 
 function getInput(inputName, required, alternativeName, alternativeValue) {
-  // We can't have both input and alternativeValue set
   let input = core.getInput(inputName, {
     required: alternativeValue ? false : required,
   })
+  // We can't have both input and alternativeValue set
   if (input && alternativeValue) {
     throw new Error(
       `Found input ${inputName}=${input} (from the YML) \

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -3,6 +3,7 @@ const { exec } = require('@actions/exec')
 const path = require('path')
 const semver = require('semver')
 const https = require('https')
+const fs = require('fs')
 const installer = require('./installer')
 
 main().catch((err) => {
@@ -12,24 +13,36 @@ main().catch((err) => {
 async function main() {
   installer.checkPlatform()
 
+  const versionFilePath = getInput('version-file', false)
+  let versions = {}
+  if (versionFilePath) {
+    if (!isStrictVersion()) {
+      throw new Error(
+        "you have to set version-type=strict if you're using version-file",
+      )
+    }
+    versions = parseVersionFile(versionFilePath)
+  }
+
   const osVersion = getRunnerOSVersion()
-  const otpSpec = core.getInput('otp-version', { required: true })
-  const elixirSpec = core.getInput('elixir-version', { required: false })
-  const gleamSpec = core.getInput('gleam-version', { required: false })
-  const rebar3Spec = core.getInput('rebar3-version', { required: false })
+  const otpSpec = getInput('otp-version', true, 'erlang', versions.erlang)
+  const elixirSpec = getInput(
+    'elixir-version',
+    false,
+    'elixir',
+    versions.elixir,
+  )
+  const gleamSpec = getInput('gleam-version', false, 'gleam', versions.gleam)
+  const rebar3Spec = getInput('rebar3-version', false, 'rebar', versions.rebar)
 
   if (otpSpec !== 'false') {
     await installOTP(otpSpec, osVersion)
     const elixirInstalled = await maybeInstallElixir(elixirSpec, otpSpec)
 
     if (elixirInstalled === true) {
-      const shouldMixRebar = core.getInput('install-rebar', {
-        required: false,
-      })
+      const shouldMixRebar = getInput('install-rebar', false)
       await mix(shouldMixRebar, 'rebar')
-      const shouldMixHex = core.getInput('install-hex', {
-        required: false,
-      })
+      const shouldMixHex = getInput('install-hex', false)
       await mix(shouldMixHex, 'hex')
     }
   } else if (!gleamSpec) {
@@ -61,9 +74,7 @@ async function maybeInstallElixir(elixirSpec, otpVersion) {
     console.log(`##[group]Installing Elixir ${elixirVersion}`)
     await installer.installElixir(elixirVersion)
     core.setOutput('elixir-version', elixirVersion)
-    const disableProblemMatchers = core.getInput('disable_problem_matchers', {
-      required: false,
-    })
+    const disableProblemMatchers = getInput('disable_problem_matchers', false)
     if (disableProblemMatchers === 'false') {
       const matchersPath = path.join(__dirname, '..', '.github')
       console.log(
@@ -310,7 +321,7 @@ async function getRebar3Versions() {
 }
 
 function isStrictVersion() {
-  return core.getInput('version-type', { required: false }) === 'strict'
+  return getInput('version-type', false) === 'strict'
 }
 
 function getVersionFromSpec(spec, versions, maybePrependWithV0) {
@@ -460,10 +471,62 @@ function isVersion(v) {
   return /^v?\d+/.test(v)
 }
 
+function getInput(inputName, required, alternativeName, alternativeValue) {
+  // We can't have both input and alternativeValue set
+  let input = core.getInput(inputName, {
+    required: alternativeValue ? false : required,
+  })
+  if (input && alternativeValue) {
+    throw new Error(
+      `Found input ${inputName}=${input} (from the YML) \
+       alongside ${alternativeName}=${alternativeValue} \
+       (from the version file). You must choose one or the other.`,
+    )
+  } else if (!input) {
+    input = alternativeValue
+  }
+  return input
+}
+
+function parseVersionFile(versionFilePath0) {
+  const versionFilePath = path.join(
+    process.env.GITHUB_WORKSPACE,
+    versionFilePath0,
+  )
+  if (!fs.existsSync(versionFilePath)) {
+    throw new Error(
+      `The specified version file, ${versionFilePath0}, does not exist`,
+    )
+  }
+  console.log(`##[group]Parsing version file at ${versionFilePath0}`)
+  const appVersions = new Map()
+  const versions = fs.readFileSync(versionFilePath, 'utf8')
+  versions.split('\n').forEach((line) => {
+    const appVersion = line.match(/^([^ ]+)[ ]+([^ #]+)/)
+    if (appVersion) {
+      const app = appVersion[1]
+      if (['erlang', 'elixir', 'gleam', 'rebar3'].includes(app)) {
+        const [, , version] = appVersion
+        console.log(`Consuming ${app} at version ${version}`)
+        appVersions.set(app, version)
+      }
+    }
+  })
+  if (!appVersions.size) {
+    console.log('There was apparently nothing to consume')
+  } else {
+    console.log('... done!')
+  }
+  console.log('##[endgroup]')
+
+  return appVersions
+}
+
 module.exports = {
   getOTPVersion,
   getElixirVersion,
   getGleamVersion,
   getRebar3Version,
   getVersionFromSpec,
+  parseVersionFile,
 }

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -497,6 +497,9 @@ function parseVersionFile(versionFilePath0) {
   console.log(`##[group]Parsing version file at ${versionFilePath0}`)
   const appVersions = new Map()
   const versions = fs.readFileSync(versionFilePath, 'utf8')
+  // For the time being we parse .tool-versions
+  // If we ever start parsing something else, this should
+  // become default in a new option named e.g. version-file-type
   versions.split('\n').forEach((line) => {
     const appVersion = line.match(/^([^ ]+)[ ]+([^ #]+)/)
     if (appVersion) {

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -475,8 +475,8 @@ function getInput(inputName, required, alternativeName, alternatives) {
   if (input && alternativeValue) {
     throw new Error(
       `Found input ${inputName}=${input} (from the YML) \
-       alongside ${alternativeName}=${alternativeValue} \
-       (from the version file). You must choose one or the other.`,
+alongside ${alternativeName}=${alternativeValue} \
+(from the version file). You must choose one or the other.`,
     )
   } else if (!input) {
     input = alternativeValue


### PR DESCRIPTION
This allows using a `.tool-versions` file as per `asdf` constraints.

The `README.md` changes should make the content of the pull request explicit.

---

**Edit**

This is working as expected as can be seen for example repo ([link to `.tool-versions`](https://github.com/paulo-ferraz-oliveira/setup-beam-example/blob/main/.tool-versions)):

- here: [success / versions installed as per `.tool-versions`](https://github.com/paulo-ferraz-oliveira/setup-beam-example/actions/runs/3501999438/jobs/5866104338#step:3:20), 
- here: [error / `version-type =/= strict`](https://github.com/paulo-ferraz-oliveira/setup-beam-example/actions/runs/3501999438/jobs/5866104338#step:4:13)
- and here: [error / colliding inputs](https://github.com/paulo-ferraz-oliveira/setup-beam-example/actions/runs/3501999438/jobs/5866104338#step:5:20)

---

Closes #137.