### PR TITLE
Provide an input for github tokens

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -9,9 +9,6 @@ on:
     branches:
       - main
 
-env:
-  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
 jobs:
   check_integrity:
     name: Expected local npm actions

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -6,8 +6,7 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
+    types: [opened, synchronize]
 
 jobs:
   check_integrity:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -9,9 +9,6 @@ on:
     branches:
       - main
 
-env:
-  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
 jobs:
   integration_test:
     name: >

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -6,8 +6,7 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
+    types: [opened, synchronize]
 
 jobs:
   integration_test:

--- a/.github/workflows/update_3rd_party_licenses.yml
+++ b/.github/workflows/update_3rd_party_licenses.yml
@@ -17,5 +17,3 @@ jobs:
           node-version: '14'
       - run:
           ./.github/workflows/update_3rd_party_licenses.sh
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,9 +9,6 @@ on:
     branches:
       - main
 
-env:
-  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
 jobs:
   integration_test:
     name: >

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,8 +6,7 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
+    types: [opened, synchronize]
 
 jobs:
   integration_test:

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,15 @@ branding:
   color: blue
   icon: code
 inputs:
+  github_token:
+    description: >
+      A github token used to access the github REST api for retrieving release and version information.
+      While this action will never perform anything more than read optionations against the github REST api,
+      we do not recommend providing a self generated personal access token which may provide more access than is
+      required of this action. This input instead is merely a conveience so that users of this action do not
+      have to manually pass an automatically generated token via their enviroment settings within a workflow.
+      [Learn more about automatically generated tokens](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)
+    default: ${{ github.token }}
   otp-version:
     description: Version range or exact version of Erlang/OTP to use,
       or false when installing only Gleam without OTP

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
       While this action will never perform anything more than read optionations against the GitHub REST API,
       we do not recommend providing a self-generated personal access token which may provide more access than is
       required of this action. This input instead is merely a convenience so that users of this action do not
-      have to manually pass an automatically generated token via their enviroment settings within a workflow.
+      have to manually pass an automatically generated token via their environment settings within a workflow.
       [Learn more about automatically generated tokens](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)
     default: ${{ github.token }}
   otp-version:

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   github-token:
     description: >
       A GitHub token used to access the GitHub REST API for retrieving release and version information.
-      While this action will never perform anything more than read optionations against the GitHub REST API,
+      While this action will never perform anything more than read operations against the GitHub REST API,
       we do not recommend providing a self-generated personal access token which may provide more access than is
       required of this action. This input instead is merely a convenience so that users of this action do not
       have to manually pass an automatically generated token via their environment settings within a workflow.

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   github-token:
     description: >
       A GitHub token used to access the GitHub REST API for retrieving release and version information.
-      While this action will never perform anything more than read optionations against the github REST api,
+      While this action will never perform anything more than read optionations against the GitHub REST API,
       we do not recommend providing a self generated personal access token which may provide more access than is
       required of this action. This input instead is merely a conveience so that users of this action do not
       have to manually pass an automatically generated token via their enviroment settings within a workflow.

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ branding:
   color: blue
   icon: code
 inputs:
-  github_token:
+  github-token:
     description: >
       A github token used to access the github REST api for retrieving release and version information.
       While this action will never perform anything more than read optionations against the github REST api,

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ branding:
 inputs:
   github-token:
     description: >
-      A github token used to access the github REST api for retrieving release and version information.
+      A GitHub token used to access the GitHub REST API for retrieving release and version information.
       While this action will never perform anything more than read optionations against the github REST api,
       we do not recommend providing a self generated personal access token which may provide more access than is
       required of this action. This input instead is merely a conveience so that users of this action do not

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
       A GitHub token used to access the GitHub REST API for retrieving release and version information.
       While this action will never perform anything more than read optionations against the GitHub REST API,
       we do not recommend providing a self-generated personal access token which may provide more access than is
-      required of this action. This input instead is merely a conveience so that users of this action do not
+      required of this action. This input instead is merely a convenience so that users of this action do not
       have to manually pass an automatically generated token via their enviroment settings within a workflow.
       [Learn more about automatically generated tokens](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)
     default: ${{ github.token }}

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: >
       A GitHub token used to access the GitHub REST API for retrieving release and version information.
       While this action will never perform anything more than read optionations against the GitHub REST API,
-      we do not recommend providing a self generated personal access token which may provide more access than is
+      we do not recommend providing a self-generated personal access token which may provide more access than is
       required of this action. This input instead is merely a conveience so that users of this action do not
       have to manually pass an automatically generated token via their enviroment settings within a workflow.
       [Learn more about automatically generated tokens](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)

--- a/dist/index.js
+++ b/dist/index.js
@@ -7613,7 +7613,7 @@ async function get(url0, pageIdxs) {
         'user-agent': 'setup-beam',
       }
       const GithubToken =
-        getInput('github-token', false) || process.env.GITHUB_TOKEN
+        getInput('github-token', false)
 
       if (GithubToken) {
         headers.authorization = `Bearer ${GithubToken}`

--- a/dist/index.js
+++ b/dist/index.js
@@ -7612,9 +7612,13 @@ async function get(url0, pageIdxs) {
       const headers = {
         'user-agent': 'setup-beam',
       }
-      if (process.env.GITHUB_TOKEN) {
-        headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`
+      const GithubToken =
+        getInput('github_token', false) || process.env.GITHUB_TOKEN
+
+      if (GithubToken) {
+        headers.authorization = `Bearer ${GithubToken}`
       }
+
       if (pageIdx !== null) {
         url.searchParams.append('page', pageIdx)
       }

--- a/dist/index.js
+++ b/dist/index.js
@@ -7612,8 +7612,7 @@ async function get(url0, pageIdxs) {
       const headers = {
         'user-agent': 'setup-beam',
       }
-      const GithubToken =
-        getInput('github-token', false)
+      const GithubToken = getInput('github-token', false)
 
       if (GithubToken) {
         headers.authorization = `Bearer ${GithubToken}`

--- a/dist/index.js
+++ b/dist/index.js
@@ -7613,7 +7613,7 @@ async function get(url0, pageIdxs) {
         'user-agent': 'setup-beam',
       }
       const GithubToken =
-        getInput('github_token', false) || process.env.GITHUB_TOKEN
+        getInput('github-token', false) || process.env.GITHUB_TOKEN
 
       if (GithubToken) {
         headers.authorization = `Bearer ${GithubToken}`

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -419,8 +419,7 @@ async function get(url0, pageIdxs) {
       const headers = {
         'user-agent': 'setup-beam',
       }
-      const GithubToken =
-        getInput('github-token', false) || process.env.GITHUB_TOKEN
+      const GithubToken = getInput('github-token', false)
 
       if (GithubToken) {
         headers.authorization = `Bearer ${GithubToken}`

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -420,7 +420,7 @@ async function get(url0, pageIdxs) {
         'user-agent': 'setup-beam',
       }
       const GithubToken =
-        getInput('github_token', false) || process.env.GITHUB_TOKEN
+        getInput('github-token', false) || process.env.GITHUB_TOKEN
 
       if (GithubToken) {
         headers.authorization = `Bearer ${GithubToken}`

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -419,9 +419,13 @@ async function get(url0, pageIdxs) {
       const headers = {
         'user-agent': 'setup-beam',
       }
-      if (process.env.GITHUB_TOKEN) {
-        headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`
+      const GithubToken =
+        getInput('github_token', false) || process.env.GITHUB_TOKEN
+
+      if (GithubToken) {
+        headers.authorization = `Bearer ${GithubToken}`
       }
+
       if (pageIdx !== null) {
         url.searchParams.append('page', pageIdx)
       }


### PR DESCRIPTION
- By providing an input for github tokens with a default users no longer have to pass the github token via their environment across workflows.