### PR TITLE
Remove Dialyzer-specific problem matcher

### DIFF
--- a/.github/elixir-matchers.json
+++ b/.github/elixir-matchers.json
@@ -57,22 +57,6 @@
           "column": 3
         }
       ]
-    },
-    {
-      "owner": "elixir-dialyzerOutputDefault",
-      "severity": "warning",
-      "pattern": [
-        {
-          "regexp": "^(.*):(\\d+):(.*)",
-          "file": 1,
-          "line": 2,
-          "code": 3
-        },
-        {
-          "regexp": "^(.*)$",
-          "message": 1
-        }
-      ]
     }
   ]
 }

--- a/__tests__/problem-matchers.test.js
+++ b/__tests__/problem-matchers.test.js
@@ -6,7 +6,6 @@ async function all() {
   await testElixirMixCompileWarning()
   await testElixirMixTestFailure()
   await testElixirCredoOutputDefault()
-  await testElixirDialyzerOutputDefault()
 }
 
 async function testElixirMixCompileError() {
@@ -72,24 +71,6 @@ async function testElixirCredoOutputDefault() {
   assert.equal(file, 'lib/test.ex')
   assert.equal(line, '15')
   assert.equal(column, '7')
-}
-
-async function testElixirDialyzerOutputDefault() {
-  const [messagePattern, filePattern] = problemMatcher.find(
-    ({ owner }) => owner === 'elixir-dialyzerOutputDefault',
-  ).pattern
-
-  const firstOutput = 'lib/test.ex:15:invalid_contract'
-  const secondOutput =
-    'The @spec for the function does not match the success typing of the function.'
-
-  const [, file, line, code] = firstOutput.match(messagePattern.regexp)
-  assert.equal(file, 'lib/test.ex')
-  assert.equal(line, '15')
-  assert.equal(code, 'invalid_contract')
-
-  const [, message] = secondOutput.match(filePattern.regexp)
-  assert.equal(message, secondOutput)
 }
 
 all()

--- a/dist/.github/elixir-matchers.json
+++ b/dist/.github/elixir-matchers.json
@@ -57,22 +57,6 @@
           "column": 3
         }
       ]
-    },
-    {
-      "owner": "elixir-dialyzerOutputDefault",
-      "severity": "warning",
-      "pattern": [
-        {
-          "regexp": "^(.*):(\\d+):(.*)",
-          "file": 1,
-          "line": 2,
-          "code": 3
-        },
-        {
-          "regexp": "^(.*)$",
-          "message": 1
-        }
-      ]
     }
   ]
 }


### PR DESCRIPTION
Turns out this problem matcher is a little too loose, which causes it to match things it shouldn't. Noticed in [this CI run](https://github.com/btkostner/jumar/actions/runs/4506127234/jobs/7932578120#step:5:153), it will match timestamps in JSON. This can be seen if you run the common `docker/setup-buildx-action@v2` (among others):

```json
  {
    "nodes": [
      {
        "name": "builder-ebda29be-8062-4a4a-9e64-efec91d5e3610",
        "endpoint": "unix:///var/run/docker.sock",
        "status": "running",
        "buildkitd-flags": "--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host",
        "buildkit": "v0.11.5",
        "platforms": "linux/amd64,linux/amd64/v2,linux/amd64/v3,linux/386"
      }
    ],
    "name": "builder-ebda29be-8062-4a4a-9e64-efec91d5e361",
    "driver": "docker-container",
    "lastActivity": "2023-03-23T23:22:29.000Z"
  }
```

Which would result in the last two lines being detected and a `warning` annotation on the last line:

```text
    "driver": "docker-container",
    "lastActivity": "2023-03-23T23:22:29.000Z"
  Warning: }
```

Instead, it's recommended to run `mix dialyzer --format github` which will use a [special GitHub actions log format](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-warning-message) to create warning annotations. This has the advantage of not being triggered for random log text. Running locally should output something like:

```text
done in 0m1.07s
::warning file=lib/kafee/producer.ex,line=1,title=pattern_match::The pattern can never match the type true.
done (warnings were emitted)
Halting VM with exit status 2
```

Default output for comparison:

```text
done in 0m1.09s
lib/kafee/producer.ex:1:pattern_match
The pattern can never match the type.

Pattern:
false

Type:
true

________________________________________________________________________________
done (warnings were emitted)
Halting VM with exit status 2
```

More information from the upstream PR: https://github.com/jeremyjh/dialyxir/pull/463