### PR TITLE
Test redirect to builds.hex.pm

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7416,7 +7416,7 @@ async function getOTPVersions(osVersion) {
   let originListing
   let pageIdxs
   if (process.platform === 'linux') {
-    originListing = `https://repo.hex.pm/builds/otp/${osVersion}/builds.txt`
+    originListing = `https://repo.hex.pm/redirect/builds/otp/${osVersion}/builds.txt`
     pageIdxs = [null]
   } else if (process.platform === 'win32') {
     originListing =
@@ -7456,7 +7456,7 @@ async function getOTPVersions(osVersion) {
 
 async function getElixirVersions() {
   const elixirVersionsListings = await get(
-    'https://repo.hex.pm/builds/elixir/builds.txt',
+    'https://repo.hex.pm/redirect/builds/elixir/builds.txt',
     [null],
   )
   const otpVersionsForElixirMap = new Map()

--- a/dist/install-elixir.ps1
+++ b/dist/install-elixir.ps1
@@ -9,7 +9,7 @@ $FILE_OUTPUT="elixir.zip"
 $DIR_FOR_BIN=".setup-beam/elixir"
 
 $ProgressPreference="SilentlyContinue"
-Invoke-WebRequest "https://repo.hex.pm/builds/elixir/${FILE_INPUT}" -OutFile "${FILE_OUTPUT}"
+Invoke-WebRequest "https://repo.hex.pm/redirect/builds/elixir/${FILE_INPUT}" -OutFile "${FILE_OUTPUT}"
 $ProgressPreference="Continue"
 New-Item "${DIR_FOR_BIN}" -ItemType Directory | Out-Null
 $ProgressPreference="SilentlyContinue"

--- a/dist/install-elixir.sh
+++ b/dist/install-elixir.sh
@@ -9,7 +9,7 @@ FILE_INPUT="${VSN}.zip"
 FILE_OUTPUT=elixir.zip
 DIR_FOR_BIN=.setup-beam/elixir
 
-wget -q -O "${FILE_OUTPUT}" "https://repo.hex.pm/builds/elixir/${FILE_INPUT}"
+wget -q -O "${FILE_OUTPUT}" "https://repo.hex.pm/redirect/builds/elixir/${FILE_INPUT}"
 mkdir -p "${DIR_FOR_BIN}"
 unzip -q -o -d "${DIR_FOR_BIN}" "${FILE_OUTPUT}"
 echo "Installed Elixir version follows"

--- a/dist/install-otp.sh
+++ b/dist/install-otp.sh
@@ -10,7 +10,7 @@ FILE_INPUT="${VSN}.tar.gz"
 FILE_OUTPUT=otp.tar.gz
 DIR_FOR_BIN=.setup-beam/otp
 
-wget -q -O "${FILE_OUTPUT}" "https://repo.hex.pm/builds/otp/${OS}/${FILE_INPUT}"
+wget -q -O "${FILE_OUTPUT}" "https://repo.hex.pm/redirect/builds/otp/${OS}/${FILE_INPUT}"
 mkdir -p "${DIR_FOR_BIN}"
 tar zxf "${FILE_OUTPUT}" -C "${DIR_FOR_BIN}" --strip-components=1
 "${DIR_FOR_BIN}/Install" -minimal "$(pwd)/${DIR_FOR_BIN}"

--- a/src/install-elixir.ps1
+++ b/src/install-elixir.ps1
@@ -9,7 +9,7 @@ $FILE_OUTPUT="elixir.zip"
 $DIR_FOR_BIN=".setup-beam/elixir"
 
 $ProgressPreference="SilentlyContinue"
-Invoke-WebRequest "https://repo.hex.pm/builds/elixir/${FILE_INPUT}" -OutFile "${FILE_OUTPUT}"
+Invoke-WebRequest "https://repo.hex.pm/redirect/builds/elixir/${FILE_INPUT}" -OutFile "${FILE_OUTPUT}"
 $ProgressPreference="Continue"
 New-Item "${DIR_FOR_BIN}" -ItemType Directory | Out-Null
 $ProgressPreference="SilentlyContinue"

--- a/src/install-elixir.sh
+++ b/src/install-elixir.sh
@@ -9,7 +9,7 @@ FILE_INPUT="${VSN}.zip"
 FILE_OUTPUT=elixir.zip
 DIR_FOR_BIN=.setup-beam/elixir
 
-wget -q -O "${FILE_OUTPUT}" "https://repo.hex.pm/builds/elixir/${FILE_INPUT}"
+wget -q -O "${FILE_OUTPUT}" "https://repo.hex.pm/redirect/builds/elixir/${FILE_INPUT}"
 mkdir -p "${DIR_FOR_BIN}"
 unzip -q -o -d "${DIR_FOR_BIN}" "${FILE_OUTPUT}"
 echo "Installed Elixir version follows"

--- a/src/install-otp.sh
+++ b/src/install-otp.sh
@@ -10,7 +10,7 @@ FILE_INPUT="${VSN}.tar.gz"
 FILE_OUTPUT=otp.tar.gz
 DIR_FOR_BIN=.setup-beam/otp
 
-wget -q -O "${FILE_OUTPUT}" "https://repo.hex.pm/builds/otp/${OS}/${FILE_INPUT}"
+wget -q -O "${FILE_OUTPUT}" "https://repo.hex.pm/redirect/builds/otp/${OS}/${FILE_INPUT}"
 mkdir -p "${DIR_FOR_BIN}"
 tar zxf "${FILE_OUTPUT}" -C "${DIR_FOR_BIN}" --strip-components=1
 "${DIR_FOR_BIN}/Install" -minimal "$(pwd)/${DIR_FOR_BIN}"

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -223,7 +223,7 @@ async function getOTPVersions(osVersion) {
   let originListing
   let pageIdxs
   if (process.platform === 'linux') {
-    originListing = `https://repo.hex.pm/builds/otp/${osVersion}/builds.txt`
+    originListing = `https://repo.hex.pm/redirect/builds/otp/${osVersion}/builds.txt`
     pageIdxs = [null]
   } else if (process.platform === 'win32') {
     originListing =
@@ -263,7 +263,7 @@ async function getOTPVersions(osVersion) {
 
 async function getElixirVersions() {
   const elixirVersionsListings = await get(
-    'https://repo.hex.pm/builds/elixir/builds.txt',
+    'https://repo.hex.pm/redirect/builds/elixir/builds.txt',
     [null],
   )
   const otpVersionsForElixirMap = new Map()


### PR DESCRIPTION
Only opening this PR to test that un-updated setup-beam versions do not break when we introduce the redirect from repo.hex.pm to builds.hex.pm.