### PR TITLE
Be explicit about which file (.bat / .cm) is executed in the Windows installation flow

### DIFF
--- a/dist/install-elixir.ps1
+++ b/dist/install-elixir.ps1
@@ -16,7 +16,7 @@ $ProgressPreference="SilentlyContinue"
 Expand-Archive -DestinationPath "${DIR_FOR_BIN}" -Path "${FILE_OUTPUT}"
 $ProgressPreference="Continue"
 Write-Output "Installed Elixir version follows"
-& "${DIR_FOR_BIN}/bin/elixir" "-v" | Write-Output
+& "${DIR_FOR_BIN}/bin/elixir.bat" "-v" | Write-Output
 
 $ProgressPreference="Continue"
 New-Item "%UserProfile%/.mix/escripts" -ItemType Directory | Out-Null

--- a/dist/install-rebar3.ps1
+++ b/dist/install-rebar3.ps1
@@ -27,6 +27,6 @@ Write-Output "@echo off`r`nescript.exe ${PWD}/${DIR_FOR_BIN}/bin/${FILE_OUTPUT} 
 Move-Item "${FILE_OUTPUT_PS1}" "${DIR_FOR_BIN}/bin"
 Move-Item "${FILE_OUTPUT_CMD}" "${DIR_FOR_BIN}/bin"
 Write-Output "Installed rebar3 version${REBAR3_NIGHTLY} follows"
-& "${DIR_FOR_BIN}/bin/rebar3" "version" | Write-Output
+& "${DIR_FOR_BIN}/bin/rebar3.cmd" "version" | Write-Output
 
 "INSTALL_DIR_FOR_REBAR3=${Env:RUNNER_TEMP}/${DIR_FOR_BIN}" | Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append

--- a/src/install-elixir.ps1
+++ b/src/install-elixir.ps1
@@ -16,7 +16,7 @@ $ProgressPreference="SilentlyContinue"
 Expand-Archive -DestinationPath "${DIR_FOR_BIN}" -Path "${FILE_OUTPUT}"
 $ProgressPreference="Continue"
 Write-Output "Installed Elixir version follows"
-& "${DIR_FOR_BIN}/bin/elixir" "-v" | Write-Output
+& "${DIR_FOR_BIN}/bin/elixir.bat" "-v" | Write-Output
 
 $ProgressPreference="Continue"
 New-Item "%UserProfile%/.mix/escripts" -ItemType Directory | Out-Null

--- a/src/install-rebar3.ps1
+++ b/src/install-rebar3.ps1
@@ -27,6 +27,6 @@ Write-Output "@echo off`r`nescript.exe ${PWD}/${DIR_FOR_BIN}/bin/${FILE_OUTPUT} 
 Move-Item "${FILE_OUTPUT_PS1}" "${DIR_FOR_BIN}/bin"
 Move-Item "${FILE_OUTPUT_CMD}" "${DIR_FOR_BIN}/bin"
 Write-Output "Installed rebar3 version${REBAR3_NIGHTLY} follows"
-& "${DIR_FOR_BIN}/bin/rebar3" "version" | Write-Output
+& "${DIR_FOR_BIN}/bin/rebar3.cmd" "version" | Write-Output
 
 "INSTALL_DIR_FOR_REBAR3=${Env:RUNNER_TEMP}/${DIR_FOR_BIN}" | Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append


### PR DESCRIPTION
In my Windows 11 test environment, using Powershell Core 7.3.4, I get the following message while running similar code to what this github action uses:

```
Installed Elixir version follows
InvalidOperation: C:\Users\vagrant\setup-beam\src\test.ps1:4
Line |
   4 |  & "${DIR_FOR_BIN}/bin/elixir" "-v" | Write-Output
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot run a document in the middle of a pipeline: C:\elixir\bin\elixir.
```

Adding `.bat` fixes the issue. This is probably not the root cause of erlef/setup-beam#189, however.