### PR TITLE
Link to the elixir/erlang compatibility page

### DIFF
--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -209,7 +209,8 @@ async function getElixirVersion(exSpec0, otpVersion0, hexMirrors) {
   } else {
     throw new Error(
       `Requested Elixir / Erlang/OTP version (${exSpec0} / ${otpVersion0}) not ` +
-        'found in version list (did you check Compatibility between Elixir and Erlang/OTP?)',
+        'found in version list (did you check Compatibility between Elixir and Erlang/OTP?).' +
+        'Elixir and Erlang/OTP compatibility can be found on: https://hexdocs.pm/elixir/compatibility-and-deprecations.html',
     )
   }
 


### PR DESCRIPTION
Currently when a user encounters an incompatibility between the requested elixir and erlang versions it isn't clear how to figure out what the compatible versions are. This is the current error as shown to users:

> Error: Requested Elixir / Erlang/OTP version (1.11.3 / 24.2) not found in version list (did you check Compatibility between Elixir and Erlang/OTP?)

Example failure: https://github.com/ScenicFramework/scenic/pull/318/checks

This PR adds a link to
https://hexdocs.pm/elixir/compatibility-and-deprecations.html so user's can easily see what versions are compatible.