### PR TITLE
🐛 Fix OTP version null check

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10221,13 +10221,10 @@ function getVersionFromSpec(spec, versions, maybePrependWithV0) {
   let version = null
 
   if (spec.match(/rc/) || isStrictVersion()) {
-    // For release candidates or when using version-type: strict,
-    // we just use the spec as the exact version...
-    if (versions.includes(spec)) {
-      // ... but only if it is in the list of available versions
-      version = spec
-    }
-  } else {
+    version = spec
+  }
+
+  if (version === null) {
     // We keep a map of semver => "spec" in order to use semver ranges to find appropriate versions
     const versionsMap = versions.sort(sortVersions).reduce((acc, v) => {
       if (!v.match(/rc/)) {
@@ -10249,7 +10246,12 @@ function getVersionFromSpec(spec, versions, maybePrependWithV0) {
   if (maybePrependWithV0 && v != null) {
     v = maybePrependWithV(v)
   }
-  return v
+
+  if (versions.includes(v)) {
+    return v
+  }
+
+  return null
 }
 
 function maybeCoerced(v) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -10221,10 +10221,13 @@ function getVersionFromSpec(spec, versions, maybePrependWithV0) {
   let version = null
 
   if (spec.match(/rc/) || isStrictVersion()) {
-    version = spec
-  }
-
-  if (version === null) {
+    // For release candidates or when using version-type: strict,
+    // we just use the spec as the exact version...
+    if (versions.includes(spec)) {
+      // ... but only if it is in the list of available versions
+      version = spec
+    }
+  } else {
     // We keep a map of semver => "spec" in order to use semver ranges to find appropriate versions
     const versionsMap = versions.sort(sortVersions).reduce((acc, v) => {
       if (!v.match(/rc/)) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -10247,11 +10247,11 @@ function getVersionFromSpec(spec, versions, maybePrependWithV0) {
     v = maybePrependWithV(v)
   }
 
-  if (versions.includes(v)) {
-    return v
+  if (!versions.includes(v)) {
+    v = null
   }
 
-  return null
+  return v
 }
 
 function maybeCoerced(v) {

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -170,7 +170,7 @@ async function getOTPVersion(otpSpec0, osVersion, hexMirrors) {
   if (isVersion(otpSpec0)) {
     otpSpec = `OTP-${otpSpec0}` // ... it's a version!
   }
-  if (otpVersion === null) {
+  if (otpVersion == null) {
     throw new Error(
       `Requested Erlang/OTP version (${otpSpec0}) not found in version list ` +
         "(should you be using option 'version-type': 'strict'?)",

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -348,7 +348,7 @@ function isStrictVersion() {
 function getVersionFromSpec(spec, versions, maybePrependWithV0) {
   let version = null
 
-  if (spec.match(/rc/) || isStrictVersion()) {
+  if ((spec.match(/rc/) || isStrictVersion()) && versions.includes(spec)) {
     version = spec
   }
 

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -375,11 +375,11 @@ function getVersionFromSpec(spec, versions, maybePrependWithV0) {
     v = maybePrependWithV(v)
   }
 
-  if (versions.includes(v)) {
-    return v
+  if (!versions.includes(v)) {
+    v = null
   }
 
-  return null
+  return v
 }
 
 function maybeCoerced(v) {

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -349,13 +349,10 @@ function getVersionFromSpec(spec, versions, maybePrependWithV0) {
   let version = null
 
   if (spec.match(/rc/) || isStrictVersion()) {
-    // For release candidates or when using version-type: strict,
-    // we just use the spec as the exact version...
-    if (versions.includes(spec)) {
-      // ... but only if it is in the list of available versions
-      version = spec
-    }
-  } else {
+    version = spec
+  }
+
+  if (version === null) {
     // We keep a map of semver => "spec" in order to use semver ranges to find appropriate versions
     const versionsMap = versions.sort(sortVersions).reduce((acc, v) => {
       if (!v.match(/rc/)) {
@@ -377,7 +374,12 @@ function getVersionFromSpec(spec, versions, maybePrependWithV0) {
   if (maybePrependWithV0 && v != null) {
     v = maybePrependWithV(v)
   }
-  return v
+
+  if (versions.includes(v)) {
+    return v
+  }
+
+  return null
 }
 
 function maybeCoerced(v) {

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -170,7 +170,7 @@ async function getOTPVersion(otpSpec0, osVersion, hexMirrors) {
   if (isVersion(otpSpec0)) {
     otpSpec = `OTP-${otpSpec0}` // ... it's a version!
   }
-  if (otpVersion == null) {
+  if (otpVersion === null) {
     throw new Error(
       `Requested Erlang/OTP version (${otpSpec0}) not found in version list ` +
         "(should you be using option 'version-type': 'strict'?)",

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -348,11 +348,14 @@ function isStrictVersion() {
 function getVersionFromSpec(spec, versions, maybePrependWithV0) {
   let version = null
 
-  if ((spec.match(/rc/) || isStrictVersion()) && versions.includes(spec)) {
-    version = spec
-  }
-
-  if (version === null) {
+  if (spec.match(/rc/) || isStrictVersion()) {
+    // For release candidates or when using version-type: strict,
+    // we just use the spec as the exact version...
+    if (versions.includes(spec)) {
+      // ... but only if it is in the list of available versions
+      version = spec
+    }
+  } else {
     // We keep a map of semver => "spec" in order to use semver ranges to find appropriate versions
     const versionsMap = versions.sort(sortVersions).reduce((acc, v) => {
       if (!v.match(/rc/)) {

--- a/test/setup-beam.test.js
+++ b/test/setup-beam.test.js
@@ -413,6 +413,13 @@ async function testGetVersionFromSpec() {
   got = setupBeam.getVersionFromSpec(spec, versions)
   assert.deepStrictEqual(got, expected)
   simulateInput('version-type', before)
+
+  before = simulateInput('version-type', 'strict')
+  spec = '22.3.4.3'
+  expected = null
+  got = setupBeam.getVersionFromSpec(spec, versions)
+  assert.deepStrictEqual(got, expected)
+  simulateInput('version-type', before)
 }
 
 async function testParseVersionFile() {


### PR DESCRIPTION
Fixes #210.

We need to check that the available `versions` contain the resolved version (which may be the original `spec`).