### PR TITLE
Add ref: (version) support to .tool-versions parsing

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10418,11 +10418,11 @@ function parseVersionFile(versionFilePath0) {
   // If we ever start parsing something else, this should
   // become default in a new option named e.g. version-file-type
   versions.split('\n').forEach((line) => {
-    const appVersion = line.match(/^([^ ]+)[ ]+([^ #]+)/)
+    const appVersion = line.match(/^([^ ]+)[ ]+(ref:v?)?([^ #]+)/)
     if (appVersion) {
       const app = appVersion[1]
       if (['erlang', 'elixir', 'gleam', 'rebar'].includes(app)) {
-        const [, , version] = appVersion
+        const [, , , version] = appVersion
         core.info(`Consuming ${app} at version ${version}`)
         appVersions.set(app, version)
       }

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -602,11 +602,11 @@ function parseVersionFile(versionFilePath0) {
   // If we ever start parsing something else, this should
   // become default in a new option named e.g. version-file-type
   versions.split('\n').forEach((line) => {
-    const appVersion = line.match(/^([^ ]+)[ ]+([^ #]+)/)
+    const appVersion = line.match(/^([^ ]+)[ ]+(ref:v)?([^ #]+)/)
     if (appVersion) {
       const app = appVersion[1]
       if (['erlang', 'elixir', 'gleam', 'rebar'].includes(app)) {
-        const [, , version] = appVersion
+        const [, , , version] = appVersion
         core.info(`Consuming ${app} at version ${version}`)
         appVersions.set(app, version)
       }

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -602,7 +602,7 @@ function parseVersionFile(versionFilePath0) {
   // If we ever start parsing something else, this should
   // become default in a new option named e.g. version-file-type
   versions.split('\n').forEach((line) => {
-    const appVersion = line.match(/^([^ ]+)[ ]+(ref:v)?([^ #]+)/)
+    const appVersion = line.match(/^([^ ]+)[ ]+(ref:v?)?([^ #]+)/)
     if (appVersion) {
       const app = appVersion[1]
       if (['erlang', 'elixir', 'gleam', 'rebar'].includes(app)) {

--- a/test/setup-beam.test.js
+++ b/test/setup-beam.test.js
@@ -510,16 +510,16 @@ async function testParseVersionFile() {
   const elixir = '1.14.1'
   const gleam = '0.23.0'
   const rebar3 = '3.16.0'
-  let toolVersions = `# a comment
-erlang   ${erlang}# comment, no space
-elixir ${elixir}  # comment, with space
+  const toolVersions = `# a comment
+erlang   ref:v${erlang}# comment, no space, and ref:v
+elixir ref:${elixir}  # comment, with space and ref:
  not-gleam 0.23 # not picked up
 gleam ${gleam} 
 rebar ${rebar3}`
   const filename = 'test/.tool-versions'
   fs.writeFileSync(filename, toolVersions)
   process.env.GITHUB_WORKSPACE = ''
-  let appVersions = setupBeam.parseVersionFile(filename)
+  const appVersions = setupBeam.parseVersionFile(filename)
   assert.strictEqual(appVersions.get('erlang'), erlang)
   assert.strictEqual(appVersions.get('elixir'), elixir)
 
@@ -540,13 +540,6 @@ rebar ${rebar3}`
   simulateInput('elixir-version', elixirVersion)
   simulateInput('gleam-version', gleamVersion)
   simulateInput('rebar3-version', rebar3Version)
-
-  // test that elixir ref:v syntax works
-  toolVersions = `erlang ${erlang}\nelixr ref:v${elixir}`
-  fs.writeFileSync(filename, toolVersions)
-  appVersions = setupBeam.parseVersionFile(filename)
-  assert.strictEqual(appVersions.get('erlang'), erlang)
-  assert.strictEqual(appVersions.get('elixir'), elixir)
 }
 
 async function testElixirMixCompileError() {

--- a/test/setup-beam.test.js
+++ b/test/setup-beam.test.js
@@ -510,7 +510,7 @@ async function testParseVersionFile() {
   const elixir = '1.14.1'
   const gleam = '0.23.0'
   const rebar3 = '3.16.0'
-  const toolVersions = `# a comment
+  let toolVersions = `# a comment
 erlang   ${erlang}# comment, no space
 elixir ${elixir}  # comment, with space
  not-gleam 0.23 # not picked up
@@ -519,7 +519,7 @@ rebar ${rebar3}`
   const filename = 'test/.tool-versions'
   fs.writeFileSync(filename, toolVersions)
   process.env.GITHUB_WORKSPACE = ''
-  const appVersions = setupBeam.parseVersionFile(filename)
+  let appVersions = setupBeam.parseVersionFile(filename)
   assert.strictEqual(appVersions.get('erlang'), erlang)
   assert.strictEqual(appVersions.get('elixir'), elixir)
 
@@ -540,6 +540,13 @@ rebar ${rebar3}`
   simulateInput('elixir-version', elixirVersion)
   simulateInput('gleam-version', gleamVersion)
   simulateInput('rebar3-version', rebar3Version)
+
+  // test that elixir ref:v syntax works
+  toolVersions = `erlang ${erlang}\nelixr ref:v${elixir}`
+  fs.writeFileSync(filename, toolVersions)
+  appVersions = setupBeam.parseVersionFile(filename)
+  assert.strictEqual(appVersions.get('erlang'), erlang)
+  assert.strictEqual(appVersions.get('elixir'), elixir)
 }
 
 async function testElixirMixCompileError() {


### PR DESCRIPTION
# Description

This adds support for using source code elixir references in `.tool-versions`, e.g., `elixir ref:v1.15.4`.


- [x] I have performed a self-review of my changes (*I was not able to run the tests locally on my mac though)
- [x] I have read and understood the [contributing guidelines](https://github.com/erlef/setup-beam/blob/main/CONTRIBUTING.md)
