### PR TITLE
Ease pre-pull request fork CI as well as github-actions based dispatch

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,13 +1,7 @@
 ---
 name: action
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+on: [push, workflow_dispatch]
 
 env:
   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/hexpm-mirrors.yml
+++ b/.github/workflows/hexpm-mirrors.yml
@@ -1,13 +1,7 @@
 ---
 name: hexpm-mirrors
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+on: [push, workflow_dispatch]
 
 jobs:
   test-failing-first-mirror:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,13 +1,7 @@
 ---
 name: ubuntu
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+on: [push, workflow_dispatch]
 
 jobs:
   integration_test:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,13 +1,7 @@
 ---
 name: windows
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+on: [push, workflow_dispatch]
 
 jobs:
   integration_test:


### PR DESCRIPTION
# Description

We allow GitHub actions pull requests to dispatch the other workflows when version updates are in order.

We also simplify the other conditions to be simply "on push".

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)
