### PR TITLE
test: otp branch matching

### DIFF
--- a/test/setup-beam.test.js
+++ b/test/setup-beam.test.js
@@ -182,6 +182,12 @@ async function testOTPVersions() {
     expected = 'OTP-20.0.5'
     got = await setupBeam.getOTPVersion(spec, osVersion)
     assert.deepStrictEqual(got, expected)
+
+    spec = 'maint'
+    osVersion = 'ubuntu-20.04'
+    expected = 'maint'
+    got = await setupBeam.getOTPVersion(spec, osVersion, hexMirrors)
+    assert.deepStrictEqual(got, expected)
   }
 
   if (process.platform === 'win32') {


### PR DESCRIPTION
# Description

Hi,

Failing test showing OTP branch matching no longer working as of `1.17`.
This test is passing for me in `1.16`.

Is that intentional or a regression?

Thanks!

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)
