### PR TITLE
Add known branch exceptions to version matching

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10224,7 +10224,7 @@ function getVersionFromSpec(spec0, versions0) {
   const rangeMax = semver.maxSatisfying(versions, rangeForMax)
   let version = null
 
-  if (isStrictVersion() || isRC(spec0)) {
+  if (isStrictVersion() || isRC(spec0) || isKnownBranch(spec0)) {
     if (versions0[spec]) {
       // If `version-type: strict` or version is RC, we obtain it directly
       version = versions0[spec]
@@ -10294,6 +10294,10 @@ function sortVersions(left, right) {
 
 function isRC(ver) {
   return ver.match(xyzAbcVersion('^', '(?:-rc\\.?\\d+)'))
+}
+
+function isKnownBranch(ver) {
+  return ['main', 'master', 'maint'].includes(ver)
 }
 
 function getRunnerOSVersion() {

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -404,7 +404,7 @@ function getVersionFromSpec(spec0, versions0) {
   const rangeMax = semver.maxSatisfying(versions, rangeForMax)
   let version = null
 
-  if (isStrictVersion() || isRC(spec0)) {
+  if (isStrictVersion() || isRC(spec0) || isKnownBranch(spec0)) {
     if (versions0[spec]) {
       // If `version-type: strict` or version is RC, we obtain it directly
       version = versions0[spec]
@@ -474,6 +474,10 @@ function sortVersions(left, right) {
 
 function isRC(ver) {
   return ver.match(xyzAbcVersion('^', '(?:-rc\\.?\\d+)'))
+}
+
+function isKnownBranch(ver) {
+  return ['main', 'master', 'maint'].includes(ver)
 }
 
 function getRunnerOSVersion() {

--- a/test/setup-beam.test.js
+++ b/test/setup-beam.test.js
@@ -182,6 +182,18 @@ async function testOTPVersions() {
     expected = 'OTP-20.0.5'
     got = await setupBeam.getOTPVersion(spec, osVersion)
     assert.deepStrictEqual(got, expected)
+
+    spec = 'maint'
+    osVersion = 'ubuntu-22.04'
+    expected = 'maint'
+    got = await setupBeam.getOTPVersion(spec, osVersion, hexMirrors)
+    assert.deepStrictEqual(got, expected)
+
+    spec = 'master'
+    osVersion = 'ubuntu-22.04'
+    expected = 'master'
+    got = await setupBeam.getOTPVersion(spec, osVersion, hexMirrors)
+    assert.deepStrictEqual(got, expected)
   }
 
   if (process.platform === 'win32') {


### PR DESCRIPTION
# Description

Maybe doing it this way is better, since we don't "break" existing consumption elements, while just adding to already existing exception `-rc-`.

Forcing `version-type: strict`, while explicit, would probably force some installations to use a too-specific Elixir version, so we "fix" what we had to prevent that.

Closes #241.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)
