### PR TITLE
Have `npm run build-dist` _always_ recreate `dist`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "shellcheck": "shellcheck .github/workflows/*.sh",
     "test": "node test/setup-beam.test.js",
     "yamllint": "yamllint .github/workflows/**.yml && yamllint .*.yml && yamllint *.yml",
-    "build-dist": "npm install && npm run build && npm run format && npm run markdownlint && npm run shellcheck && npm run yamllint && npm run jslint"
+    "build-dist": "rm -rf ./dist && npm install && npm run build && npm run format && npm run markdownlint && npm run shellcheck && npm run yamllint && npm run jslint"
   },
   "dependencies": {
     "@actions/core": "1.10.0",


### PR DESCRIPTION
# Description

So we don't get keep files we no longer need. I wanted to have pushed this with #246 but I didn't push the local commit 😄 

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)
