### PR TITLE
Hack around `rebar3` compiling your project to output its `version`

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10562,8 +10562,9 @@ async function install(toolName, opts) {
           reportVersion: () => {
             const cmd = 'erl'
             const args = ['-version']
+            const env = {}
 
-            return [cmd, args]
+            return [cmd, args, env]
           },
         },
         win32: {
@@ -10579,8 +10580,9 @@ async function install(toolName, opts) {
           reportVersion: () => {
             const cmd = 'erl.exe'
             const args = ['+V']
+            const env = {}
 
-            return [cmd, args]
+            return [cmd, args, env]
           },
         },
       }
@@ -10608,8 +10610,9 @@ async function install(toolName, opts) {
           reportVersion: () => {
             const cmd = 'elixir'
             const args = ['-v']
+            const env = {}
 
-            return [cmd, args]
+            return [cmd, args, env]
           },
         },
       }
@@ -10648,8 +10651,9 @@ async function install(toolName, opts) {
           reportVersion: () => {
             const cmd = 'gleam'
             const args = ['--version']
+            const env = {}
 
-            return [cmd, args]
+            return [cmd, args, env]
           },
         },
         win32: {
@@ -10681,8 +10685,9 @@ async function install(toolName, opts) {
           reportVersion: () => {
             const cmd = 'gleam.exe'
             const args = ['--version']
+            const env = {}
 
-            return [cmd, args]
+            return [cmd, args, env]
           },
         },
       }
@@ -10713,8 +10718,12 @@ async function install(toolName, opts) {
           reportVersion: () => {
             const cmd = 'rebar3'
             const args = ['version']
+            const env = {
+              REBAR_GLOBAL_CONFIG_DIR: '/fake-dir',
+              REBAR_CONFIG: 'fake.config',
+            }
 
-            return [cmd, args]
+            return [cmd, args, env]
           },
         },
         win32: {
@@ -10749,8 +10758,9 @@ async function install(toolName, opts) {
           reportVersion: () => {
             const cmd = 'rebar3.cmd'
             const args = ['version']
+            const env = {}
 
-            return [cmd, args]
+            return [cmd, args, env]
           },
         },
       }
@@ -10804,8 +10814,8 @@ async function installTool(opts) {
   core.exportVariable(installDirForVarName, runnerToolPath)
 
   core.info(`Installed ${installOpts.tool} version`)
-  const [cmd, args] = platformOpts.reportVersion()
-  await exec(cmd, args)
+  const [cmd, args, env] = platformOpts.reportVersion()
+  await exec(cmd, args, { env: { ...process.env, ...env } })
 }
 
 function checkPlatform() {

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -731,8 +731,9 @@ async function install(toolName, opts) {
           reportVersion: () => {
             const cmd = 'erl'
             const args = ['-version']
+            const env = {}
 
-            return [cmd, args]
+            return [cmd, args, env]
           },
         },
         win32: {
@@ -748,8 +749,9 @@ async function install(toolName, opts) {
           reportVersion: () => {
             const cmd = 'erl.exe'
             const args = ['+V']
+            const env = {}
 
-            return [cmd, args]
+            return [cmd, args, env]
           },
         },
       }
@@ -777,8 +779,9 @@ async function install(toolName, opts) {
           reportVersion: () => {
             const cmd = 'elixir'
             const args = ['-v']
+            const env = {}
 
-            return [cmd, args]
+            return [cmd, args, env]
           },
         },
       }
@@ -817,8 +820,9 @@ async function install(toolName, opts) {
           reportVersion: () => {
             const cmd = 'gleam'
             const args = ['--version']
+            const env = {}
 
-            return [cmd, args]
+            return [cmd, args, env]
           },
         },
         win32: {
@@ -850,8 +854,9 @@ async function install(toolName, opts) {
           reportVersion: () => {
             const cmd = 'gleam.exe'
             const args = ['--version']
+            const env = {}
 
-            return [cmd, args]
+            return [cmd, args, env]
           },
         },
       }
@@ -882,8 +887,12 @@ async function install(toolName, opts) {
           reportVersion: () => {
             const cmd = 'rebar3'
             const args = ['version']
+            const env = {
+              REBAR_GLOBAL_CONFIG_DIR: '/fake-dir',
+              REBAR_CONFIG: 'fake.config',
+            }
 
-            return [cmd, args]
+            return [cmd, args, env]
           },
         },
         win32: {
@@ -918,8 +927,9 @@ async function install(toolName, opts) {
           reportVersion: () => {
             const cmd = 'rebar3.cmd'
             const args = ['version']
+            const env = {}
 
-            return [cmd, args]
+            return [cmd, args, env]
           },
         },
       }
@@ -973,8 +983,8 @@ async function installTool(opts) {
   core.exportVariable(installDirForVarName, runnerToolPath)
 
   core.info(`Installed ${installOpts.tool} version`)
-  const [cmd, args] = platformOpts.reportVersion()
-  await exec(cmd, args)
+  const [cmd, args, env] = platformOpts.reportVersion()
+  await exec(cmd, args, { env: { ...process.env, ...env } })
 }
 
 function checkPlatform() {


### PR DESCRIPTION
# Description

What are we fixing?

If you're `with`ing `"version-file": ".tool-versions"` after you `uses` `"actions/checkout"`, it's likely `rebar3` from `setup-beam` is compiling your project just to output its
version.

This commit prevents that as per
https://github.com/erlang/rebar3/issues/2865#issuecomment-1958608973

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)
