### PR TITLE
Allow absolute version file paths

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10422,7 +10422,7 @@ alongside ${alternativeName}=${alternativeValue} \
 }
 
 function parseVersionFile(versionFilePath0) {
-  const versionFilePath = path.join(
+  const versionFilePath = path.resolve(
     process.env.GITHUB_WORKSPACE,
     versionFilePath0,
   )

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -591,7 +591,7 @@ alongside ${alternativeName}=${alternativeValue} \
 }
 
 function parseVersionFile(versionFilePath0) {
-  const versionFilePath = path.join(
+  const versionFilePath = path.resolve(
     process.env.GITHUB_WORKSPACE,
     versionFilePath0,
   )

--- a/test/setup-beam.test.js
+++ b/test/setup-beam.test.js
@@ -8,6 +8,8 @@ simulateInput('hexpm-mirrors', 'https://builds.hex.pm', { multiline: true })
 
 const assert = require('assert')
 const fs = require('fs')
+const os = require('os')
+const path = require('path')
 const core = require('@actions/core')
 const setupBeam = require('../src/setup-beam')
 const { problemMatcher } = require('../matchers/elixir-matchers.json')
@@ -534,6 +536,14 @@ rebar ${rebar3}`
   const appVersions = setupBeam.parseVersionFile(filename)
   assert.strictEqual(appVersions.get('erlang'), erlang)
   assert.strictEqual(appVersions.get('elixir'), elixir)
+
+  const absoluteFilename = path.join(os.tmpdir(), '.tool-versions')
+  fs.writeFileSync(absoluteFilename, toolVersions)
+
+  process.env.GITHUB_WORKSPACE = process.cwd()
+  const absoluteAppVersions = setupBeam.parseVersionFile(absoluteFilename)
+  assert.strictEqual(absoluteAppVersions.get('erlang'), erlang)
+  assert.strictEqual(absoluteAppVersions.get('elixir'), elixir)
 
   assert.ok(async () => {
     await setupBeam.install('otp', { toolVersion: erlang })


### PR DESCRIPTION
# Description

When using an absolute path like `/tmp/.tool-versions`, the action would look in the file `/$GITHUB_WORKSPACE/tmp/.tool-versions`. This change lets it consider absolute paths as well.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)
