### PR TITLE
Fix CI for pull requests

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,7 +1,7 @@
 ---
 name: action
 
-on: [push, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch]
 
 env:
   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/hexpm-mirrors.yml
+++ b/.github/workflows/hexpm-mirrors.yml
@@ -1,7 +1,7 @@
 ---
 name: hexpm-mirrors
 
-on: [push, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test-failing-first-mirror:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,7 +1,7 @@
 ---
 name: ubuntu
 
-on: [push, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   integration_test:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,7 +1,7 @@
 ---
 name: windows
 
-on: [push, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   integration_test:


### PR DESCRIPTION
# Description

It seems `pull_request` is required for CI to run when not pushing to the repo itself.

- [ ] I have performed a self-review of my changes
- [ ] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)
