### PR TITLE
Add GITHUB_TOKEN information to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,13 @@ Here are a few things you can do that will increase the likelihood of your pull 
 - Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 - Execute `npm run build-dist` and fix any issues arising from that
 
+## Running tests
+
+When running tests locally, a valid classic GitHub token with the `repo` scope is required for tests to pass.
+
+- Export the token in the current shell: `export GITHUB_TOKEN=<contents>`
+- Run tests `npm test`
+
 ## Resources
 
 - [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)


### PR DESCRIPTION
# Description

I ran into this issue earlier today in a different pull request, and was informed about this requirement. I thought that it would be helpful for other contributors to know that `GITHUB_TOKEN` is a required environment variable for running tests.

Closes #&lt;issue&gt;.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)
