### PR TITLE
Test over OTP 27 and rebar3 3.23

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         combo:
           - otp-version: '27'
+            elixir-version: 'v1.17.0-rc1'
             rebar3-version: '3.23'
             os: 'ubuntu-latest'
           - otp-version: '26.0'

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -22,7 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         combo:
-          - otp-version: 'OTP-27.0-rc1'
+          - otp-version: '27'
+            rebar3-version: '3.23'
             os: 'ubuntu-latest'
           - otp-version: '26.0'
             elixir-version: 'v1.14-otp-25'

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -50,7 +50,7 @@ jobs:
           - otp-version: '25'
             os: 'ubuntu-24.04'
           - otp-version: '25'
-            elixir-version: '1'
+            elixir-version: '1.16'
             rebar3-version: '3'
             os: 'ubuntu-22.04'
           - otp-version: '24'

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -54,7 +54,7 @@ jobs:
             rebar3-version: '3'
             os: 'ubuntu-22.04'
           - otp-version: '24'
-            elixir-version: '1'
+            elixir-version: '1.16'
             rebar3-version: '3'
             os: 'ubuntu-22.04'
           - otp-version: '25.0'

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         combo:
           - otp-version: '27'
-            elixir-version: 'v1.17.0-rc1'
+            elixir-version: 'v1.17.0-rc.0'
             rebar3-version: '3.23'
             os: 'ubuntu-latest'
           - otp-version: '26.0'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         combo:
           - otp-version: '27'
+            elixir-version: 'v1.17.0-rc1'
             rebar3-version: '3.23'
             os: 'windows-latest'
           - otp-version: '26.0'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         combo:
           - otp-version: '27'
-            elixir-version: 'v1.17.0-rc1'
+            elixir-version: 'v1.17.0-rc.0'
             rebar3-version: '3.23'
             os: 'windows-latest'
           - otp-version: '26.0'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,7 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         combo:
-          - otp-version: 'OTP-27.0-rc1'
+          - otp-version: '27'
+            rebar3-version: '3.23'
             os: 'windows-latest'
           - otp-version: '26.0'
             elixir-version: 'main'

--- a/README.md
+++ b/README.md
@@ -49,13 +49,14 @@ opt-in, so `1.11.x` will not match a pre-release.
 This list presents the known working version combos between the target operating system
 and Erlang/OTP.
 
-| Operating system | Erlang/OTP | Status
-|-                 |-           |-
-| ubuntu-18.04     | 17 - 25    | ✅
-| ubuntu-20.04     | 20 - 25    | ✅
-| ubuntu-22.04     | 24.2 - 26  | ✅
-| windows-2019     | 21* - 25   | ✅
-| windows-2022     | 21* - 26   | ✅
+| Operating system | Erlang/OTP  | Status
+|-                 |-            |-
+| ubuntu-18.04     | 17.0 - 25.3 | ✅
+| ubuntu-20.04     | 20.0 - 27   | ✅
+| ubuntu-22.04     | 24.2 - 27   | ✅
+| ubuntu-24.04     | 24.3 - 27   | ✅
+| windows-2019     | 21* - 25    | ✅
+| windows-2022     | 21* - 27    | ✅
 
 **Note** *: prior to 23, Windows builds are only available for minor versions, e.g. 21.0, 21.3, 22.0, etc.
 


### PR DESCRIPTION
# Description

I make explicit tests over the newest version of `rebar3` over the newest version of Erlang/OTP. Can't add Elixir to the mix, still, but once we can (1.16, 1.17?) the file is easily updated.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)
