### PR TITLE
Test under non-RC Elixir 1.17

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         combo:
           - otp-version: '27'
-            elixir-version: 'v1.17.0-rc.0'
+            elixir-version: 'v1.17.0'
             rebar3-version: '3.23'
             os: 'ubuntu-latest'
           - otp-version: '26.0'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         combo:
           - otp-version: '27'
-            elixir-version: 'v1.17.0-rc.0'
+            elixir-version: 'v1.17.0'
             rebar3-version: '3.23'
             os: 'windows-latest'
           - otp-version: '26.0'


### PR DESCRIPTION
# Description

Not that non-RC Elixir 1.17 is release, we use that in our tests.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)
