### PR TITLE
Update CI now that `rebar3` nightly no longer supports OTP 24

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -70,7 +70,7 @@ jobs:
           - otp-version: '25'
             rebar3-version: 'nightly'
             os: 'ubuntu-latest'
-          - otp-version: '24'
+          - otp-version: '26'
             rebar3-version: 'nightly'
             os: 'ubuntu-latest'
           - elixir-version: 'v1.4'
@@ -201,9 +201,9 @@ jobs:
       fail-fast: false
       matrix:
         combo:
-          - otp-version: '24'
-            elixir-version: 'v1.12'
-            gleam-version: '0.23.0-rc1'
+          - otp-version: '25'
+            elixir-version: 'v1.14'
+            gleam-version: '1.0.0'
             rebar3-version: 'nightly'
             os: 'ubuntu-latest'
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -44,7 +44,7 @@ jobs:
           - otp-version: '24.0.2'
             rebar3-version: '3.16'
             os: 'windows-2019'
-          - otp-version: '24.0.2'
+          - otp-version: '26.2.5'
             rebar3-version: 'nightly'
             os: 'windows-2019'
           - otp-version: '23.0'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -131,9 +131,9 @@ jobs:
       fail-fast: false
       matrix:
         combo:
-          - otp-version: '24'
-            elixir-version: 'v1.12'
-            gleam-version: '0.23.0-rc1'
+          - otp-version: '25'
+            elixir-version: 'v1.14'
+            gleam-version: '1.0.0'
             rebar3-version: 'nightly'
             os: 'windows-latest'
     steps:


### PR DESCRIPTION
# Description

This unblocks other pull requests, like:

* https://github.com/erlef/setup-beam/pull/281
* https://github.com/erlef/setup-beam/pull/269

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)
