### PR TITLE
Fixup action name for the GH marketplace

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 ---
-name: Setup Erlang/OTP with optional Elixir (and mix) and/or rebar3
+name: setup-beam
 description: >
   Set up a specific version of Erlang/OTP, Elixir, and/or rebar3
   and add the command-line tools to the PATH


### PR DESCRIPTION
We seemed to have published to the marketplace previously with a description of the action vs the action name. This commit changes the name to simply `setup-beam`.

The link that is out there : `https://github.com/marketplace/actions/setup-erlang-otp-with-optional-elixir-and-mix-and-or-rebar3` 

Additionally, if you search for `setup-beam` or `beam` this will action not come up. We may want to revise the description while we are here. 

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)
