### PR TITLE
Fix usage of version `latest` not matching internal elements

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9536,6 +9536,8 @@ function getVersionFromSpec(spec0, versions0) {
       // If `version-type: strict` or version is RC, we obtain it directly
       version = versions0[spec]
     }
+  } else if (spec0 === 'latest') {
+    version = versions0[versions0.latest]
   } else if (rangeMax !== null) {
     // Otherwise, we compare alt. versions' semver ranges to this version, from highest to lowest
     const thatVersion = spec
@@ -9604,7 +9606,7 @@ function isRC(ver) {
 }
 
 function isKnownBranch(ver) {
-  return ['main', 'master', 'maint', 'latest'].includes(ver)
+  return ['main', 'master', 'maint'].includes(ver)
 }
 
 function githubARMRunnerArchs() {

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -436,6 +436,8 @@ function getVersionFromSpec(spec0, versions0) {
       // If `version-type: strict` or version is RC, we obtain it directly
       version = versions0[spec]
     }
+  } else if (spec0 === 'latest') {
+    version = versions0[versions0.latest]
   } else if (rangeMax !== null) {
     // Otherwise, we compare alt. versions' semver ranges to this version, from highest to lowest
     const thatVersion = spec
@@ -504,7 +506,7 @@ function isRC(ver) {
 }
 
 function isKnownBranch(ver) {
-  return ['main', 'master', 'maint', 'latest'].includes(ver)
+  return ['main', 'master', 'maint'].includes(ver)
 }
 
 function githubARMRunnerArchs() {


### PR DESCRIPTION
# Description

~Add integration test.~ Fix latest

@paulo-ferraz-oliveira, there are some flaky tests or a bug in the version resolution, which is unrelated to my changes.

Closes #297 

- [X] I have performed a self-review of my changes
- [X] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)
