### PR TITLE
Fix CI (don't use 26.2.5 on Windows; be strict when comparing versions)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -44,7 +44,7 @@ jobs:
           - otp-version: '24.0.2'
             rebar3-version: '3.16'
             os: 'windows-2019'
-          - otp-version: '26.2.5'
+          - otp-version: '26.1'
             rebar3-version: 'nightly'
             os: 'windows-2019'
           - otp-version: '23.0'

--- a/test/setup-beam.test.js
+++ b/test/setup-beam.test.js
@@ -183,15 +183,17 @@ async function testOTPVersions() {
     expected = 'maint-26'
     got = await setupBeam.getOTPVersion(spec, osVersion)
     assert.deepStrictEqual(got, expected)
-
     simulateInput('version-type', before)
+
+    before = simulateInput('version-type', 'strict')
     spec = '27.0'
     osVersion = 'ubuntu-24.04'
     expected = 'OTP-27.0'
     got = await setupBeam.getOTPVersion(spec, osVersion)
     assert.deepStrictEqual(got, expected)
-
     simulateInput('version-type', before)
+
+    before = simulateInput('version-type', 'strict')
     spec = '25.3.2.1'
     osVersion = 'ubuntu-20.04'
     expected = 'OTP-25.3.2.1'
@@ -308,15 +310,17 @@ async function testLinuxARM64OTPVersions() {
     expected = 'maint-26'
     got = await setupBeam.getOTPVersion(spec, osVersion)
     assert.deepStrictEqual(got, expected)
-
     simulateInput('version-type', before)
+
+    before = simulateInput('version-type', 'strict')
     spec = '27.0'
     osVersion = 'ubuntu-24.04'
     expected = 'OTP-27.0'
     got = await setupBeam.getOTPVersion(spec, osVersion)
     assert.deepStrictEqual(got, expected)
-
     simulateInput('version-type', before)
+
+    before = simulateInput('version-type', 'strict')
     spec = '25.3.2.1'
     osVersion = 'ubuntu-20.04'
     expected = 'OTP-25.3.2.1'
@@ -393,22 +397,24 @@ async function testLinuxAMD64OTPVersions() {
     expected = 'maint-26'
     got = await setupBeam.getOTPVersion(spec, osVersion)
     assert.deepStrictEqual(got, expected)
-
     simulateInput('version-type', before)
+
+    before = simulateInput('version-type', 'strict')
     spec = '27.0'
     osVersion = 'ubuntu-24.04'
     expected = 'OTP-27.0'
     got = await setupBeam.getOTPVersion(spec, osVersion)
     assert.deepStrictEqual(got, expected)
-
     simulateInput('version-type', before)
+
+    before = simulateInput('version-type', 'strict')
     spec = '25.3.2.1'
     osVersion = 'ubuntu-20.04'
     expected = 'OTP-25.3.2.1'
     got = await setupBeam.getOTPVersion(spec, osVersion)
     assert.deepStrictEqual(got, expected)
-
     simulateInput('version-type', before)
+
     spec = '19.3.x'
     osVersion = 'ubuntu-16.04'
     expected = 'OTP-19.3.6.13'
@@ -562,6 +568,7 @@ async function testElixirVersions() {
   got = await setupBeam.getElixirVersion(spec, otpVersion)
   assert.deepStrictEqual(got, expected)
   simulateInput('version-type', before)
+
   simulateInput('hexpm-mirrors', hexMirrors, { multiline: true })
 }
 


### PR DESCRIPTION
# Description

1. remove Windows 26.2.5 from tests: (resolved) 26.2.5.2 is [not installing properly](https://github.com/erlang/otp/issues/8666), but the action's CI shouldn't be affected for this.

2. properly simulate `version-type` `strict` when required to not have e.g. `27.0` identify as (recently released) `27.0.1` when that's unexpected.

## Motivation

The motivation for this change was the report in #298, which made me look into why we had issues with version resolution. (issue is not in code, but tests' expectations)

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)
