### PR TITLE
feat: setup custom retry with builtin node fetch

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -7,7 +7,7 @@ on:
       - main
   pull_request:
     branches:
-      - "*"
+      - '*'
   workflow_dispatch: {}
 
 env:
@@ -62,6 +62,7 @@ jobs:
         id: setup-beam
         uses: ./
         with:
+          install-rebar: false
           version-file: test/.tool-versions
           version-type: strict
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,7 +7,7 @@ on:
       - main
   pull_request:
     branches:
-      - "*"
+      - '*'
   workflow_dispatch: {}
 
 jobs:
@@ -50,10 +50,6 @@ jobs:
           - otp-version: '25'
             os: 'ubuntu-24.04'
           - otp-version: '25'
-            elixir-version: '1.16'
-            rebar3-version: '3'
-            os: 'ubuntu-22.04'
-          - otp-version: '24'
             elixir-version: '1.16'
             rebar3-version: '3'
             os: 'ubuntu-22.04'
@@ -121,7 +117,7 @@ jobs:
             otp-version: false
             os: 'ubuntu-latest'
             disable_problem_matchers: true
-          - gleam-version: '0.22.0'  # Version with Gleam's old archive naming convention
+          - gleam-version: '0.22.0' # Version with Gleam's old archive naming convention
             otp-version: '24'
             os: 'ubuntu-latest'
             disable_problem_matchers: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -9661,7 +9661,10 @@ function getRunnerOSVersion() {
 
 async function getUrlResponse(url, headers, attempt = 1) {
   try {
-    const response = await fetch(url, { headers })
+    const response = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(10000),
+    })
     const contentType = response.headers.get('content-type') || ''
 
     if (!response.ok) {
@@ -10157,6 +10160,7 @@ function debugLoggingEnabled() {
 }
 
 module.exports = {
+  get,
   getOTPVersion,
   getElixirVersion,
   getGleamVersion,

--- a/dist/index.js
+++ b/dist/index.js
@@ -9106,11 +9106,12 @@ exports["default"] = _default;
 const core = __nccwpck_require__(2186)
 const { exec } = __nccwpck_require__(1514)
 const tc = __nccwpck_require__(7784)
-const http = __nccwpck_require__(6255)
 const path = __nccwpck_require__(1017)
 const semver = __nccwpck_require__(1383)
 const fs = __nccwpck_require__(7147)
 const os = __nccwpck_require__(2037)
+
+const MAX_HTTP_RETRIES = 3
 
 main().catch((err) => {
   core.setFailed(err.message)
@@ -9361,8 +9362,7 @@ async function getOTPVersions(osVersion) {
       hexMirrors: hexMirrorsInput(),
       actionTitle: `fetch ${originListing}`,
       action: async (hexMirror) => {
-        const l = await get(`${hexMirror}${originListing}`, [null])
-        return l
+        return get(`${hexMirror}${originListing}`, [])
       },
     })
   } else if (process.platform === 'win32') {
@@ -9413,8 +9413,7 @@ async function getElixirVersions() {
     hexMirrors: hexMirrorsInput(),
     actionTitle: `fetch ${originListing}`,
     action: async (hexMirror) => {
-      const l = await get(`${hexMirror}${originListing}`, [null])
-      return l
+      return get(`${hexMirror}${originListing}`, [])
     },
   })
   const otpVersionsForElixirMap = {}
@@ -9660,38 +9659,50 @@ function getRunnerOSVersion() {
   return containerFromEnvImageOS
 }
 
+async function getUrlResponse(url, headers, attempt = 1) {
+  try {
+    const response = await fetch(url, { headers })
+    const contentType = response.headers.get('content-type') || ''
+
+    if (!response.ok) {
+      throw new Error(`Got ${response.statusCode} from ${url}`)
+    }
+
+    if (contentType.indexOf('application/json') !== -1) {
+      return response.json()
+    } else {
+      return response.text()
+    }
+  } catch (err) {
+    if (attempt >= MAX_HTTP_RETRIES) {
+      core.debug(`Error during fetch. Retrying in 1000ms: ${err}`)
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+      return getUrlResponse(url, headers, attempt + 1)
+    } else {
+      throw err
+    }
+  }
+}
+
 async function get(url0, pageIdxs) {
-  async function getPage(pageIdx) {
-    const url = new URL(url0)
-    const headers = {}
-    const GithubToken = getInput('github-token', false)
-    if (GithubToken && url.host === 'api.github.com') {
-      headers.authorization = `Bearer ${GithubToken}`
-    }
-
-    if (pageIdx !== null) {
-      url.searchParams.append('page', pageIdx)
-    }
-
-    const httpClient = new http.HttpClient('setup-beam', [], {
-      allowRetries: true,
-      maxRetries: 3,
-    })
-    const response = await httpClient.get(url, headers)
-    if (response.statusCode >= 400 && response.statusCode <= 599) {
-      throw new Error(
-        `Got ${response.statusCode} from ${url}. Exiting with error`,
-      )
-    }
-
-    return response.readBody()
+  const url = new URL(url0)
+  const headers = {}
+  const GithubToken = getInput('github-token', false)
+  if (GithubToken && url.host === 'api.github.com') {
+    headers.authorization = `Bearer ${GithubToken}`
   }
 
-  if (pageIdxs[0] === null) {
-    return getPage(null)
+  if (pageIdxs.length === 0) {
+    return getUrlResponse(url, headers)
+  } else {
+    return Promise.all(
+      pageIdxs.map((page) => {
+        const urlWithPage = new URL(url)
+        urlWithPage.searchParams.append('page', page)
+        return getUrlResponse(urlWithPage, headers)
+      }),
+    )
   }
-
-  return Promise.all(pageIdxs.map(getPage))
 }
 
 function maybePrependWithV(v) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -9665,7 +9665,7 @@ async function getUrlResponse(url, headers, attempt = 1) {
     const contentType = response.headers.get('content-type') || ''
 
     if (!response.ok) {
-      throw new Error(`Got ${response.statusCode} from ${url}`)
+      throw new Error(response.statusText)
     }
 
     if (contentType.indexOf('application/json') !== -1) {
@@ -9674,9 +9674,12 @@ async function getUrlResponse(url, headers, attempt = 1) {
       return response.text()
     }
   } catch (err) {
+    core.debug(`Error fetching from ${url}: ${err}`)
+
     if (attempt <= MAX_HTTP_RETRIES) {
-      core.debug(`Error during fetch. Retrying in 1000ms: ${err}`)
-      await new Promise((resolve) => setTimeout(resolve, 1000))
+      const delay = attempt * 2 * 1000
+      core.debug(`Error during fetch. Retrying in ${delay}ms`)
+      await new Promise((resolve) => setTimeout(resolve, delay))
       return getUrlResponse(url, headers, attempt + 1)
     } else {
       throw err

--- a/dist/index.js
+++ b/dist/index.js
@@ -9389,7 +9389,7 @@ async function getOTPVersions(osVersion) {
       })
   } else if (process.platform === 'win32') {
     otpVersionsListings.forEach((otpVersionsListing) => {
-      jsonParseAsList(otpVersionsListing)
+      otpVersionsListing
         .map((x) => x.assets)
         .flat()
         .filter((x) => x.name.match(/^otp_win64_.*.exe$/))
@@ -9446,7 +9446,7 @@ async function getGleamVersions() {
   )
   const gleamVersionsListing = {}
   resultJSONs.forEach((resultJSON) => {
-    jsonParseAsList(resultJSON)
+    resultJSON
       .map((x) => x.tag_name)
       .forEach((ver) => {
         const gleamMatch = ver.match(/^v?([^ ]+)/)
@@ -9465,7 +9465,7 @@ async function getRebar3Versions() {
   )
   const rebar3VersionsListing = {}
   resultJSONs.forEach((resultJSON) => {
-    jsonParseAsList(resultJSON)
+    resultJSON
       .map((x) => x.tag_name)
       .forEach((ver) => {
         rebar3VersionsListing[ver] = ver
@@ -9795,21 +9795,6 @@ function parseVersionFile(versionFilePath0) {
   core.endGroup()
 
   return appVersions
-}
-
-function jsonParseAsList(maybeJson) {
-  try {
-    const obj = JSON.parse(maybeJson)
-    if (!Array.isArray(obj)) {
-      throw new Error('expected a list!')
-    }
-
-    return obj
-  } catch (exc) {
-    throw new Error(
-      `Got an exception when trying to parse non-JSON list ${maybeJson}: ${exc}`,
-    )
-  }
 }
 
 function debugLog(groupName, message) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -9674,7 +9674,7 @@ async function getUrlResponse(url, headers, attempt = 1) {
       return response.text()
     }
   } catch (err) {
-    if (attempt >= MAX_HTTP_RETRIES) {
+    if (attempt <= MAX_HTTP_RETRIES) {
       core.debug(`Error during fetch. Retrying in 1000ms: ${err}`)
       await new Promise((resolve) => setTimeout(resolve, 1000))
       return getUrlResponse(url, headers, attempt + 1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "dependencies": {
         "@actions/core": "1.10.0",
         "@actions/exec": "1.1.1",
-        "@actions/http-client": "2.1.0",
         "@actions/tool-cache": "2.0.1",
         "semver": "7.6.2"
       },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "@actions/core": "1.10.0",
     "@actions/exec": "1.1.1",
-    "@actions/http-client": "2.1.0",
     "@actions/tool-cache": "2.0.1",
     "semver": "7.6.2"
   },

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -289,7 +289,7 @@ async function getOTPVersions(osVersion) {
       })
   } else if (process.platform === 'win32') {
     otpVersionsListings.forEach((otpVersionsListing) => {
-      jsonParseAsList(otpVersionsListing)
+      otpVersionsListing
         .map((x) => x.assets)
         .flat()
         .filter((x) => x.name.match(/^otp_win64_.*.exe$/))
@@ -346,7 +346,7 @@ async function getGleamVersions() {
   )
   const gleamVersionsListing = {}
   resultJSONs.forEach((resultJSON) => {
-    jsonParseAsList(resultJSON)
+    resultJSON
       .map((x) => x.tag_name)
       .forEach((ver) => {
         const gleamMatch = ver.match(/^v?([^ ]+)/)
@@ -365,7 +365,7 @@ async function getRebar3Versions() {
   )
   const rebar3VersionsListing = {}
   resultJSONs.forEach((resultJSON) => {
-    jsonParseAsList(resultJSON)
+    resultJSON
       .map((x) => x.tag_name)
       .forEach((ver) => {
         rebar3VersionsListing[ver] = ver
@@ -695,21 +695,6 @@ function parseVersionFile(versionFilePath0) {
   core.endGroup()
 
   return appVersions
-}
-
-function jsonParseAsList(maybeJson) {
-  try {
-    const obj = JSON.parse(maybeJson)
-    if (!Array.isArray(obj)) {
-      throw new Error('expected a list!')
-    }
-
-    return obj
-  } catch (exc) {
-    throw new Error(
-      `Got an exception when trying to parse non-JSON list ${maybeJson}: ${exc}`,
-    )
-  }
 }
 
 function debugLog(groupName, message) {

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -561,7 +561,10 @@ function getRunnerOSVersion() {
 
 async function getUrlResponse(url, headers, attempt = 1) {
   try {
-    const response = await fetch(url, { headers })
+    const response = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(10000),
+    })
     const contentType = response.headers.get('content-type') || ''
 
     if (!response.ok) {
@@ -1057,6 +1060,7 @@ function debugLoggingEnabled() {
 }
 
 module.exports = {
+  get,
   getOTPVersion,
   getElixirVersion,
   getGleamVersion,

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -574,7 +574,7 @@ async function getUrlResponse(url, headers, attempt = 1) {
       return response.text()
     }
   } catch (err) {
-    if (attempt >= MAX_HTTP_RETRIES) {
+    if (attempt <= MAX_HTTP_RETRIES) {
       core.debug(`Error during fetch. Retrying in 1000ms: ${err}`)
       await new Promise((resolve) => setTimeout(resolve, 1000))
       return getUrlResponse(url, headers, attempt + 1)

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -565,7 +565,7 @@ async function getUrlResponse(url, headers, attempt = 1) {
     const contentType = response.headers.get('content-type') || ''
 
     if (!response.ok) {
-      throw new Error(`Got ${response.statusCode} from ${url}`)
+      throw new Error(response.statusText)
     }
 
     if (contentType.indexOf('application/json') !== -1) {
@@ -574,9 +574,12 @@ async function getUrlResponse(url, headers, attempt = 1) {
       return response.text()
     }
   } catch (err) {
+    core.debug(`Error fetching from ${url}: ${err}`)
+
     if (attempt <= MAX_HTTP_RETRIES) {
-      core.debug(`Error during fetch. Retrying in 1000ms: ${err}`)
-      await new Promise((resolve) => setTimeout(resolve, 1000))
+      const delay = attempt * 2 * 1000
+      core.debug(`Error during fetch. Retrying in ${delay}ms`)
+      await new Promise((resolve) => setTimeout(resolve, delay))
       return getUrlResponse(url, headers, attempt + 1)
     } else {
       throw err

--- a/test/setup-beam.test.js
+++ b/test/setup-beam.test.js
@@ -7,6 +7,7 @@ simulateInput('github-token', process.env.GITHUB_TOKEN)
 simulateInput('hexpm-mirrors', 'https://builds.hex.pm', { multiline: true })
 
 const assert = require('assert')
+const http = require('http')
 const fs = require('fs')
 const os = require('os')
 const path = require('path')
@@ -71,8 +72,8 @@ async function all() {
   await testRebar3Versions()
 
   await testGetVersionFromSpec()
-
   await testParseVersionFile()
+  await testGetRetry()
 
   await testElixirMixCompileError()
   await testElixirMixCompileWarning()
@@ -911,6 +912,28 @@ gleam ${gleam} \nrebar ${rebar3}`
   simulateInput('elixir-version', elixirVersion)
   simulateInput('gleam-version', gleamVersion)
   simulateInput('rebar3-version', rebar3Version)
+}
+
+async function testGetRetry() {
+  let attempt = 0
+  const server = http.createServer((req, res) => {
+    attempt++
+    if (attempt == 2) {
+      res.write('correct!')
+      res.end()
+    }
+  })
+
+  try {
+    server.listen(0)
+    const port = server.address().port
+
+    const response = await setupBeam.get(`http://localhost:${port}`, [])
+    assert.equal(response, 'correct!')
+    assert.equal(attempt, 2)
+  } finally {
+    server.close()
+  }
 }
 
 async function testElixirMixCompileError() {

--- a/test/setup-beam.test.js
+++ b/test/setup-beam.test.js
@@ -874,7 +874,7 @@ async function testParseVersionFile() {
   const erlang = '27'
   const elixir = '1.17.0'
   const gleam = '0.23.0'
-  const rebar3 = '3.23'
+  const rebar3 = '3.24.0'
   const toolVersions = `# a comment
 erlang   ref:v${erlang}# comment, no space, and ref:v
 elixir ref:${elixir}  # comment, with space and ref:

--- a/test/setup-beam.test.js
+++ b/test/setup-beam.test.js
@@ -871,10 +871,10 @@ async function testParseVersionFile() {
   const gleamVersion = unsimulateInput('gleam-version')
   const rebar3Version = unsimulateInput('rebar3-version')
 
-  const erlang = '25.1.1'
-  const elixir = '1.14.1'
+  const erlang = '27'
+  const elixir = '1.17.0'
   const gleam = '0.23.0'
-  const rebar3 = '3.16.0'
+  const rebar3 = '3.23'
   const toolVersions = `# a comment
 erlang   ref:v${erlang}# comment, no space, and ref:v
 elixir ref:${elixir}  # comment, with space and ref:


### PR DESCRIPTION
# Description

This action uses node 20, which now has the built in `fetch` implementation. We can use that instead of the `@action/http-client` package. This allows us to do our own retry implementation to fix the long standing issue #260.

Closes issue: #260

- [ ] I have performed a self-review of my changes
- [X] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)
