### PR TITLE
Compatibility matrix strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,59 @@ jobs:
       - run: rebar3 ct
 ```
 
+### Compatibility
+
+One can run matrix-style testing but with pinned compatible versions in the following manner:
+
+```yaml
+  test:
+    runs-on: ${{matrix.erlang.os}}
+    name: Erlang/OTP ${{matrix.erlang.otp}} / rebar3 ${{matrix.erlang.rebar3}}
+    strategy:
+      matrix:
+        erlang:
+          - otp: "17"
+            rebar3: "3.10.0"
+            os: ubuntu-18.04
+          - otp: "18"
+            rebar3: "3.11.1"
+            os: ubuntu-18.04
+          - otp: "19"
+            rebar3: "3.15.2"
+            os: ubuntu-18.04
+          - otp: "20.3.8.26"
+            rebar3: "3.15.2"
+            os: ubuntu-18.04
+          - otp: "21.3.8.17"
+            rebar3: "3.15.2"
+            os: ubuntu-20.04
+          - otp: "22.3.4.9"
+            rebar3: "3.16.1"
+            os: ubuntu-20.04
+          - otp: "23.3.4.5"
+            rebar3: "3.16.1"
+            os: ubuntu-22.04
+          - otp: "24.3.4.17"
+            rebar3: "3.16.1"
+            os: ubuntu-22.04
+          - otp: "25.3.2.15"
+            rebar3: "3.22.1"
+            os: ubuntu-24.04
+          - otp: "26.2.5.5"
+            rebar3: "3.22.1"
+            os: ubuntu-24.04
+          - otp: "27.1.2"
+            rebar3: "3.22.1"
+            os: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.erlang.otp}}
+          rebar3-version: ${{matrix.erlang.rebar3}}
+      - run: rebar3 eunit
+```
+
 ### Erlang/OTP + `rebar3`, on Windows
 
 ```yaml


### PR DESCRIPTION
# Description

Example on how one can maintain a compatibility matrix.
Note I've not tested keeping the os-version in the strategy itself, but according to the github documentation it works for the runs-on argument as well.

I'm currently running otp-rebar pinning for another project for OTP22-OTP27 versions below.
And I ran a similar thing (though not with erlef/setup-beam) previously for the same project for OTP17-21.

I'll add the os-version to my project for testing, but I wanted early feedback on your thoughts.

- [X] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)
