### PR TITLE
Fix invalid Markdown in Compatibility section

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This list presents the known working version combos between the target operating
 and Erlang/OTP.
 
 | Operating system | Erlang/OTP   | OTP Architecture | Status
-|-                 |-             |                  |-
+|-                 |-             | -                |-
 | `ubuntu-18.04`   | 17.0 - 25.3  | x86_64, arm64    | ✅
 | `ubuntu-20.04`   | 21.0 - 27    | x86_64, arm64    | ✅
 | `ubuntu-22.04`   | 24.2 - 27    | x86_64, arm64    | ✅


### PR DESCRIPTION
# Description

![image](https://github.com/user-attachments/assets/784ff05c-ee92-4445-9d33-19f356e4c4fb)


- [x] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)
