### PR TITLE
Override OTP version when specified in Elixir spec

### DIFF
--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -184,7 +184,14 @@ async function getOTPVersion(otpSpec0, osVersion) {
 
 async function getElixirVersion(exSpec0, otpVersion0) {
   const otpVersion = otpVersion0.match(/^([^-]+-)?(.+)$/)[2]
-  const otpVersionMajor = otpVersion.match(/^([^.]+).*$/)[1]
+  let otpVersionMajor = otpVersion.match(/^([^.]+).*$/)[1]
+
+  const userSuppliedOtp = exSpec0.match(/-otp-(\d+)/)?.[1] ?? null
+
+  if (userSuppliedOtp && isVersion(userSuppliedOtp) && userSuppliedOtp !== otpVersionMajor) {
+    core.warning(`Elixir built for Erlang/OTP ${userSuppliedOtp} does not match the specified Erlang/OTP version ${otpVersionMajor}`)
+    otpVersionMajor = userSuppliedOtp
+  }
 
   const [otpVersionsForElixirMap, elixirVersions] = await getElixirVersions()
   const spec = exSpec0.replace(/-otp-.*$/, '')

--- a/test/setup-beam.test.js
+++ b/test/setup-beam.test.js
@@ -511,6 +511,12 @@ describe('.getOTPVersion(_) - Elixir', () => {
     got = await setupBeam.getElixirVersion(spec, otpVersion)
     assert.deepStrictEqual(got, expected)
 
+    spec = '1.16.2-otp-26'
+    otpVersion = 'OTP-27'
+    expected = 'v1.16.2-otp-26'
+    got = await setupBeam.getElixirVersion(spec, otpVersion)
+    assert.deepStrictEqual(got, expected)
+
     spec = '1.12.1'
     otpVersion = 'OTP-24.0.2'
     expected = 'v1.12.1-otp-24'


### PR DESCRIPTION
# Description

When specifying an Elixir version like `1.18.4-otp-27`and OTP version `28.0` the action would overwrite this to `1.18.4-otp-28` which does not exist, although the versions are compatible. This fixes the issue by overriding the OTP major version when specified in the spec

Closes #329 .

- [x] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)
