### PR TITLE
Fix broken link `CODE_OF_CONDUCT.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 [fork]: https://github.com/erlef/setup-beam/fork
 [pr]: https://github.com/erlef/setup-beam/compare
-[code-of-conduct]: https://github.com/erlef/setup-beam/blob/main/CODE_OF_CONDUCT.md
+[code-of-conduct]: https://github.com/erlef/.github/blob/main/CODE_OF_CONDUCT.md
 
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for
 keeping it great.

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Check out [this doc](CONTRIBUTING.md).
 
 ### Code of Conduct
 
-This project's code of conduct is made explicit in [CODE_OF_CONDUCT.md](https://github.com/erlef/setup-beam/blob/main/CODE_OF_CONDUCT.md).
+This project's code of conduct is made explicit in [CODE_OF_CONDUCT.md](https://github.com/erlef/.github/blob/main/CODE_OF_CONDUCT.md).
 
 ### Security
 


### PR DESCRIPTION
# Description
Fix broken link in README. It fix issue https://github.com/erlef/setup-beam/issues/326.
