### PR TITLE
Match only on what we know should match (versions start with numbers, after OTP-)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -26067,9 +26067,12 @@ function requestedVersionFor(tool, version, originListing, mirrors) {
   )
 }
 
+const knownBranches = ['main', 'master', 'maint']
+
 async function getElixirVersion(exSpec0, otpVersion0) {
   const otpVersion = otpVersion0.match(/^(?:OTP-)?(.+)$/)[1]
-  let otpVersionMajor = otpVersion.match(/^([^.]+).*$/)[1]
+  const regex = `^(\\d{1,3}|${knownBranches.join('|')})?.*$`
+  let otpVersionMajor = otpVersion.match(new RegExp(regex))[1]
 
   const otpSuffix = /-otp-(\d+)/
   const userSuppliedOtp = exSpec0.match(otpSuffix)?.[1] ?? null
@@ -26434,8 +26437,6 @@ function sortVersions(left, right) {
 function isRC(ver) {
   return ver.match(xyzAbcVersion('^', '(?:-rc\\.?\\d+)'))
 }
-
-const knownBranches = ['main', 'master', 'maint']
 
 function isKnownBranch(ver) {
   return knownBranches.includes(ver)

--- a/dist/index.js
+++ b/dist/index.js
@@ -26068,10 +26068,11 @@ function requestedVersionFor(tool, version, originListing, mirrors) {
 }
 
 const knownBranches = ['main', 'master', 'maint']
+const nonSpecificVersions = ['nightly', 'latest']
 
 async function getElixirVersion(exSpec0, otpVersion0) {
   const otpVersion = otpVersion0.match(/^(?:OTP-)?(.+)$/)[1]
-  const regex = `^(\\d{1,3}|${knownBranches.join('|')})?.*$`
+  const regex = `^(\\d{1,3}|${knownBranches.join('|')}|${nonSpecificVersions.join('|')})?.*$`
   let otpVersionMajor = otpVersion.match(new RegExp(regex))[1]
 
   const otpSuffix = /-otp-(\d+)/
@@ -26319,7 +26320,9 @@ function gt(left, right) {
 
 function validVersion(v) {
   return (
-    v.match(/main|master|nightly|latest/g) == null &&
+    v.match(
+      new RegExp(`${knownBranches.join('|')}|${nonSpecificVersions.join('|')}`),
+    ) == null &&
     !v.startsWith('a') &&
     !v.startsWith('b')
   )

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -193,10 +193,11 @@ function requestedVersionFor(tool, version, originListing, mirrors) {
 }
 
 const knownBranches = ['main', 'master', 'maint']
+const nonSpecificVersions = ['nightly', 'latest']
 
 async function getElixirVersion(exSpec0, otpVersion0) {
   const otpVersion = otpVersion0.match(/^(?:OTP-)?(.+)$/)[1]
-  const regex = `^(\\d{1,3}|${knownBranches.join('|')})?.*$`
+  const regex = `^(\\d{1,3}|${knownBranches.join('|')}|${nonSpecificVersions.join('|')})?.*$`
   let otpVersionMajor = otpVersion.match(new RegExp(regex))[1]
 
   const otpSuffix = /-otp-(\d+)/
@@ -444,7 +445,9 @@ function gt(left, right) {
 
 function validVersion(v) {
   return (
-    v.match(/main|master|nightly|latest/g) == null &&
+    v.match(
+      new RegExp(`${knownBranches.join('|')}|${nonSpecificVersions.join('|')}`),
+    ) == null &&
     !v.startsWith('a') &&
     !v.startsWith('b')
   )

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -192,9 +192,12 @@ function requestedVersionFor(tool, version, originListing, mirrors) {
   )
 }
 
+const knownBranches = ['main', 'master', 'maint']
+
 async function getElixirVersion(exSpec0, otpVersion0) {
   const otpVersion = otpVersion0.match(/^(?:OTP-)?(.+)$/)[1]
-  let otpVersionMajor = otpVersion.match(/^([^.]+).*$/)[1]
+  const regex = `^(\\d{1,3}|${knownBranches.join('|')})?.*$`
+  let otpVersionMajor = otpVersion.match(new RegExp(regex))[1]
 
   const otpSuffix = /-otp-(\d+)/
   const userSuppliedOtp = exSpec0.match(otpSuffix)?.[1] ?? null
@@ -559,8 +562,6 @@ function sortVersions(left, right) {
 function isRC(ver) {
   return ver.match(xyzAbcVersion('^', '(?:-rc\\.?\\d+)'))
 }
-
-const knownBranches = ['main', 'master', 'maint']
 
 function isKnownBranch(ver) {
   return knownBranches.includes(ver)


### PR DESCRIPTION
# Description

Act on a weakness update suggested by CodeQL's scanning: https://github.com/erlef/setup-beam/security/code-scanning/23.

(at most 3 digits for major version)

- [x] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)
