### PR TITLE
Fix calculating `-otp-` major for Elixir

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -76,6 +76,7 @@ jobs:
         uses: ./
         with:
           install-rebar: false
+          install-hex: false
           version-file: test/.tool-versions
           version-type: strict
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -25,6 +25,15 @@ jobs:
       fail-fast: false
       matrix:
         combo:
+          - otp-version: '<26'
+            elixir-version: '<1.17'
+            os: 'ubuntu-22.04'
+          - otp-version: 'master'
+            elixir-version: '> 0'
+            os: 'ubuntu-24.04'
+          - otp-version: 'master'
+            elixir-version: 'main'
+            os: 'ubuntu-24.04'
           - otp-version: '27'
             elixir-version: 'v1.17.0'
             rebar3-version: '3.23'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,6 +25,12 @@ jobs:
       fail-fast: false
       matrix:
         combo:
+          - otp-version: '<26'
+            elixir-version: '<1.17'
+            os: 'ubuntu-22.04'
+          - otp-version: 'master'
+            elixir-version: '> 0'
+            os: 'ubuntu-24.04'
           - otp-version: '27'
             elixir-version: 'v1.17.0'
             rebar3-version: '3.23'

--- a/dist/index.js
+++ b/dist/index.js
@@ -25910,15 +25910,14 @@ async function main() {
     versions = parseVersionFile(versionFilePath)
   }
 
-  const osVersion = getRunnerOSVersion()
   const otpSpec = getInput('otp-version', true, 'erlang', versions)
   const elixirSpec = getInput('elixir-version', false, 'elixir', versions)
   const gleamSpec = getInput('gleam-version', false, 'gleam', versions)
   const rebar3Spec = getInput('rebar3-version', false, 'rebar', versions)
 
   if (otpSpec !== 'false') {
-    await installOTP(otpSpec, osVersion)
-    const elixirInstalled = await maybeInstallElixir(elixirSpec, otpSpec)
+    await installOTP(otpSpec)
+    const elixirInstalled = await maybeInstallElixir(elixirSpec)
     if (elixirInstalled === true) {
       const shouldMixRebar = getInput('install-rebar', false)
       await mix(shouldMixRebar, 'rebar')
@@ -25938,7 +25937,8 @@ async function main() {
   core.setOutput('setup-beam-version', setupBeamVersion)
 }
 
-async function installOTP(otpSpec, osVersion) {
+async function installOTP(otpSpec) {
+  const osVersion = getRunnerOSVersion()
   const otpVersion = await getOTPVersion(otpSpec, osVersion)
   core.startGroup(
     `Installing Erlang/OTP ${otpVersion} - built on ${getRunnerOSArchitecture()}/${osVersion}`,
@@ -25960,10 +25960,10 @@ async function installOTP(otpSpec, osVersion) {
   return otpVersion
 }
 
-async function maybeInstallElixir(elixirSpec, otpSpec) {
+async function maybeInstallElixir(elixirSpec) {
   let installed = false
   if (elixirSpec) {
-    const elixirVersion = await getElixirVersion(elixirSpec, otpSpec)
+    const elixirVersion = await getElixirVersion(elixirSpec)
     core.startGroup(`Installing Elixir ${elixirVersion}`)
     await doWithMirrors({
       hexMirrors: hexMirrorsInput(),
@@ -26072,16 +26072,30 @@ function requestedVersionFor(tool, version, originListing, mirrors) {
 const knownBranches = ['main', 'master', 'maint']
 const nonSpecificVersions = ['nightly', 'latest']
 
-async function getElixirVersion(exSpec0, otpVersion0) {
-  const otpVersion = otpVersion0.match(/^(?:OTP-)?(.+)$/)[1]
-  const regex = `^(\\d{1,3}|${knownBranches.join('|')}|${nonSpecificVersions.join('|')})?.*$`
-  let otpVersionMajor = otpVersion.match(new RegExp(regex))[1]
-
+async function getElixirVersion(exSpec0) {
   const otpSuffix = /-otp-(\d+)/
   const userSuppliedOtp = exSpec0.match(otpSuffix)?.[1] ?? null
+  let otpVersionMajor = ''
 
   if (userSuppliedOtp && isVersion(userSuppliedOtp)) {
     otpVersionMajor = userSuppliedOtp
+  } else {
+    let cmd = 'erl'
+    if (process.platform === 'win32') {
+      cmd = 'erl.exe'
+    }
+    const args = [
+      '-noshell',
+      '-eval',
+      'io:format(erlang:system_info(otp_release)), halt().',
+    ]
+    await exec(cmd, args, {
+      listeners: {
+        stdout: (data) => {
+          otpVersionMajor = data.toString()
+        },
+      },
+    })
   }
 
   const [otpVersionsForElixirMap, elixirVersions, originListing, hexMirrors] =
@@ -26096,17 +26110,29 @@ async function getElixirVersion(exSpec0, otpVersion0) {
     )
   }
 
-  const elixirVersionComp = otpVersionsForElixirMap[elixirVersionFromSpec]
-  if (
-    (elixirVersionComp && elixirVersionComp.includes(otpVersionMajor)) ||
-    !isVersion(otpVersionMajor)
-  ) {
-    core.info(
-      `Using Elixir ${elixirVersionFromSpec} (built for Erlang/OTP ${otpVersionMajor})`,
-    )
-  } else {
+  let foundCombo = false
+  let otpVersionMajorIter = parseInt(otpVersionMajor)
+  let otpVersionsMajor = []
+  while (otpVersionMajorIter > otpVersionMajor - 3) {
+    otpVersionMajorIter += ''
+    otpVersionsMajor.push(otpVersionMajorIter)
+    const elixirVersionComp = otpVersionsForElixirMap[elixirVersionFromSpec]
+    if (
+      (elixirVersionComp && elixirVersionComp.includes(otpVersionMajorIter)) ||
+      !isVersion(otpVersionMajorIter)
+    ) {
+      core.info(
+        `Using Elixir ${elixirVersionFromSpec} (built for Erlang/OTP ${otpVersionMajorIter})`,
+      )
+      foundCombo = true
+      break
+    }
+    otpVersionMajorIter = parseInt(otpVersionMajorIter) - 1
+  }
+
+  if (!foundCombo) {
     throw new Error(
-      `Requested Elixir / Erlang/OTP version (${exSpec0} / ${otpVersion0}) not ` +
+      `Requested Elixir / Erlang/OTP version (${exSpec0} / tried ${otpVersionsMajor}) not ` +
         'found in version list (did you check Compatibility between Elixir and Erlang/OTP?).' +
         'Elixir and Erlang/OTP compatibility can be found at: ' +
         'https://hexdocs.pm/elixir/compatibility-and-deprecations.html',
@@ -26115,8 +26141,8 @@ async function getElixirVersion(exSpec0, otpVersion0) {
 
   let elixirVersionForDownload = elixirVersionFromSpec
 
-  if (isVersion(otpVersionMajor)) {
-    elixirVersionForDownload = `${elixirVersionFromSpec}-otp-${otpVersionMajor}`
+  if (isVersion(otpVersionMajorIter)) {
+    elixirVersionForDownload = `${elixirVersionFromSpec}-otp-${otpVersionMajorIter}`
   }
 
   return maybePrependWithV(elixirVersionForDownload)

--- a/dist/index.js
+++ b/dist/index.js
@@ -25890,9 +25890,11 @@ const _ = __nccwpck_require__(2356)
 
 const MAX_HTTP_RETRIES = 3
 
-main().catch((err) => {
-  core.setFailed(err.message)
-})
+if (process.env.NODE_ENV !== 'test') {
+  main().catch((err) => {
+    core.setFailed(err.message)
+  })
+}
 
 async function main() {
   checkOtpArchitecture()
@@ -27073,14 +27075,18 @@ function debugLoggingEnabled() {
 
 module.exports = {
   get,
-  getOTPVersion,
   getElixirVersion,
   getGleamVersion,
+  getOTPVersion,
   getRebar3Version,
   getVersionFromSpec,
   githubAMDRunnerArchs,
   githubARMRunnerArchs,
   install,
+  installOTP,
+  maybeInstallElixir,
+  maybeInstallGleam,
+  maybeInstallRebar3,
   parseVersionFile,
 }
 

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -10,9 +10,11 @@ const _ = require('lodash')
 
 const MAX_HTTP_RETRIES = 3
 
-main().catch((err) => {
-  core.setFailed(err.message)
-})
+if (process.env.NODE_ENV !== 'test') {
+  main().catch((err) => {
+    core.setFailed(err.message)
+  })
+}
 
 async function main() {
   checkOtpArchitecture()
@@ -1198,13 +1200,17 @@ function debugLoggingEnabled() {
 
 module.exports = {
   get,
-  getOTPVersion,
   getElixirVersion,
   getGleamVersion,
+  getOTPVersion,
   getRebar3Version,
   getVersionFromSpec,
   githubAMDRunnerArchs,
   githubARMRunnerArchs,
   install,
+  installOTP,
+  maybeInstallElixir,
+  maybeInstallGleam,
+  maybeInstallRebar3,
   parseVersionFile,
 }

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -30,15 +30,14 @@ async function main() {
     versions = parseVersionFile(versionFilePath)
   }
 
-  const osVersion = getRunnerOSVersion()
   const otpSpec = getInput('otp-version', true, 'erlang', versions)
   const elixirSpec = getInput('elixir-version', false, 'elixir', versions)
   const gleamSpec = getInput('gleam-version', false, 'gleam', versions)
   const rebar3Spec = getInput('rebar3-version', false, 'rebar', versions)
 
   if (otpSpec !== 'false') {
-    await installOTP(otpSpec, osVersion)
-    const elixirInstalled = await maybeInstallElixir(elixirSpec, otpSpec)
+    await installOTP(otpSpec)
+    const elixirInstalled = await maybeInstallElixir(elixirSpec)
     if (elixirInstalled === true) {
       const shouldMixRebar = getInput('install-rebar', false)
       await mix(shouldMixRebar, 'rebar')
@@ -58,7 +57,8 @@ async function main() {
   core.setOutput('setup-beam-version', setupBeamVersion)
 }
 
-async function installOTP(otpSpec, osVersion) {
+async function installOTP(otpSpec) {
+  const osVersion = getRunnerOSVersion()
   const otpVersion = await getOTPVersion(otpSpec, osVersion)
   core.startGroup(
     `Installing Erlang/OTP ${otpVersion} - built on ${getRunnerOSArchitecture()}/${osVersion}`,
@@ -80,10 +80,10 @@ async function installOTP(otpSpec, osVersion) {
   return otpVersion
 }
 
-async function maybeInstallElixir(elixirSpec, otpSpec) {
+async function maybeInstallElixir(elixirSpec) {
   let installed = false
   if (elixirSpec) {
-    const elixirVersion = await getElixirVersion(elixirSpec, otpSpec)
+    const elixirVersion = await getElixirVersion(elixirSpec)
     core.startGroup(`Installing Elixir ${elixirVersion}`)
     await doWithMirrors({
       hexMirrors: hexMirrorsInput(),
@@ -197,16 +197,30 @@ function requestedVersionFor(tool, version, originListing, mirrors) {
 const knownBranches = ['main', 'master', 'maint']
 const nonSpecificVersions = ['nightly', 'latest']
 
-async function getElixirVersion(exSpec0, otpVersion0) {
-  const otpVersion = otpVersion0.match(/^(?:OTP-)?(.+)$/)[1]
-  const regex = `^(\\d{1,3}|${knownBranches.join('|')}|${nonSpecificVersions.join('|')})?.*$`
-  let otpVersionMajor = otpVersion.match(new RegExp(regex))[1]
-
+async function getElixirVersion(exSpec0) {
   const otpSuffix = /-otp-(\d+)/
   const userSuppliedOtp = exSpec0.match(otpSuffix)?.[1] ?? null
+  let otpVersionMajor = ''
 
   if (userSuppliedOtp && isVersion(userSuppliedOtp)) {
     otpVersionMajor = userSuppliedOtp
+  } else {
+    let cmd = 'erl'
+    if (process.platform === 'win32') {
+      cmd = 'erl.exe'
+    }
+    const args = [
+      '-noshell',
+      '-eval',
+      'io:format(erlang:system_info(otp_release)), halt().',
+    ]
+    await exec(cmd, args, {
+      listeners: {
+        stdout: (data) => {
+          otpVersionMajor = data.toString()
+        },
+      },
+    })
   }
 
   const [otpVersionsForElixirMap, elixirVersions, originListing, hexMirrors] =
@@ -221,17 +235,29 @@ async function getElixirVersion(exSpec0, otpVersion0) {
     )
   }
 
-  const elixirVersionComp = otpVersionsForElixirMap[elixirVersionFromSpec]
-  if (
-    (elixirVersionComp && elixirVersionComp.includes(otpVersionMajor)) ||
-    !isVersion(otpVersionMajor)
-  ) {
-    core.info(
-      `Using Elixir ${elixirVersionFromSpec} (built for Erlang/OTP ${otpVersionMajor})`,
-    )
-  } else {
+  let foundCombo = false
+  let otpVersionMajorIter = parseInt(otpVersionMajor)
+  let otpVersionsMajor = []
+  while (otpVersionMajorIter > otpVersionMajor - 3) {
+    otpVersionMajorIter += ''
+    otpVersionsMajor.push(otpVersionMajorIter)
+    const elixirVersionComp = otpVersionsForElixirMap[elixirVersionFromSpec]
+    if (
+      (elixirVersionComp && elixirVersionComp.includes(otpVersionMajorIter)) ||
+      !isVersion(otpVersionMajorIter)
+    ) {
+      core.info(
+        `Using Elixir ${elixirVersionFromSpec} (built for Erlang/OTP ${otpVersionMajorIter})`,
+      )
+      foundCombo = true
+      break
+    }
+    otpVersionMajorIter = parseInt(otpVersionMajorIter) - 1
+  }
+
+  if (!foundCombo) {
     throw new Error(
-      `Requested Elixir / Erlang/OTP version (${exSpec0} / ${otpVersion0}) not ` +
+      `Requested Elixir / Erlang/OTP version (${exSpec0} / tried ${otpVersionsMajor}) not ` +
         'found in version list (did you check Compatibility between Elixir and Erlang/OTP?).' +
         'Elixir and Erlang/OTP compatibility can be found at: ' +
         'https://hexdocs.pm/elixir/compatibility-and-deprecations.html',
@@ -240,8 +266,8 @@ async function getElixirVersion(exSpec0, otpVersion0) {
 
   let elixirVersionForDownload = elixirVersionFromSpec
 
-  if (isVersion(otpVersionMajor)) {
-    elixirVersionForDownload = `${elixirVersionFromSpec}-otp-${otpVersionMajor}`
+  if (isVersion(otpVersionMajorIter)) {
+    elixirVersionForDownload = `${elixirVersionFromSpec}-otp-${otpVersionMajorIter}`
   }
 
   return maybePrependWithV(elixirVersionForDownload)

--- a/test/setup-beam.test.js
+++ b/test/setup-beam.test.js
@@ -1,3 +1,5 @@
+process.env.NODE_ENV = 'test'
+
 simulateInput('otp-version', '25.1.2')
 simulateInput('otp-architecture', '64')
 simulateInput('elixir-version', '1.14.2')

--- a/test/setup-beam.test.js
+++ b/test/setup-beam.test.js
@@ -536,77 +536,70 @@ describe('.getOTPVersion(_) - Elixir', () => {
   let spec
   let otpVersion
   let before
-  const hexMirrors = simulateInput('hexpm-mirrors', 'https://repo.hex.pm', {
-    multiline: true,
-  })
+  const previousRunnerArch = process.env.RUNNER_ARCH
 
-  it('returns the expected value', async () => {
-    spec = '1.1.x'
-    otpVersion = 'OTP-17'
-    expected = 'v1.1.1-otp-17'
-    got = await setupBeam.getElixirVersion(spec, otpVersion)
-    assert.deepStrictEqual(got, expected)
+  if (process.platform === 'linux') {
+    process.env.RUNNER_ARCH = 'X64'
 
-    spec = '1.10.4'
-    otpVersion = 'OTP-23'
-    expected = 'v1.10.4-otp-23'
-    got = await setupBeam.getElixirVersion(spec, otpVersion)
-    assert.deepStrictEqual(got, expected)
+    it('returns the expected value', async () => {
+      spec = '1.18.x'
+      otpVersion = 'OTP-27'
+      expected = 'v1.18.4-otp-27'
+      await setupBeam.installOTP(otpVersion)
+      got = await setupBeam.getElixirVersion(spec, otpVersion)
+      assert.deepStrictEqual(got, expected)
 
-    spec = '1.16.2-otp-26'
-    otpVersion = 'OTP-27'
-    expected = 'v1.16.2-otp-26'
-    got = await setupBeam.getElixirVersion(spec, otpVersion)
-    assert.deepStrictEqual(got, expected)
+      spec = '1.18.2'
+      otpVersion = 'OTP-27'
+      expected = 'v1.18.2-otp-27'
+      await setupBeam.installOTP(otpVersion)
+      got = await setupBeam.getElixirVersion(spec, otpVersion)
+      assert.deepStrictEqual(got, expected)
 
-    spec = '1.12.1'
-    otpVersion = 'OTP-24.0.2'
-    expected = 'v1.12.1-otp-24'
-    got = await setupBeam.getElixirVersion(spec, otpVersion)
-    assert.deepStrictEqual(got, expected)
+      spec = '1.16.2-otp-26'
+      otpVersion = 'OTP-27'
+      expected = 'v1.16.2-otp-26'
+      await setupBeam.installOTP(otpVersion)
+      got = await setupBeam.getElixirVersion(spec, otpVersion)
+      assert.deepStrictEqual(got, expected)
 
-    before = simulateInput('version-type', 'strict')
-    spec = '1.14.0'
-    otpVersion = 'main'
-    expected = 'v1.14.0'
-    got = await setupBeam.getElixirVersion(spec, otpVersion)
-    assert.deepStrictEqual(got, expected)
-    simulateInput('version-type', before)
+      spec = '1.12.1'
+      otpVersion = 'OTP-24.3.4'
+      expected = 'v1.12.1-otp-24'
+      await setupBeam.installOTP(otpVersion)
+      got = await setupBeam.getElixirVersion(spec, otpVersion)
+      assert.deepStrictEqual(got, expected)
 
-    before = simulateInput('version-type', 'strict')
-    spec = 'v1.11.0-rc.0'
-    otpVersion = 'OTP-23'
-    expected = 'v1.11.0-rc.0-otp-23'
-    got = await setupBeam.getElixirVersion(spec, otpVersion)
-    assert.deepStrictEqual(got, expected)
-    simulateInput('version-type', before)
+      before = simulateInput('version-type', 'strict')
+      spec = '1.17'
+      otpVersion = 'master'
+      expected = 'v1.17-otp-27'
+      await setupBeam.installOTP(otpVersion)
+      got = await setupBeam.getElixirVersion(spec, otpVersion)
+      assert.deepStrictEqual(got, expected)
+      simulateInput('version-type', before)
 
-    before = simulateInput('version-type', 'strict')
-    spec = 'v1.11.0-rc.0-otp-23'
-    otpVersion = 'OTP-23'
-    expected = 'v1.11.0-rc.0-otp-23'
-    got = await setupBeam.getElixirVersion(spec, otpVersion)
-    assert.deepStrictEqual(got, expected)
-    simulateInput('version-type', before)
+      before = simulateInput('version-type', 'strict')
+      spec = 'v1.15.0-rc.2'
+      otpVersion = 'OTP-26'
+      expected = 'v1.15.0-rc.2-otp-26'
+      await setupBeam.installOTP(otpVersion)
+      got = await setupBeam.getElixirVersion(spec, otpVersion)
+      assert.deepStrictEqual(got, expected)
+      simulateInput('version-type', before)
 
-    before = simulateInput('version-type', 'strict')
-    spec = 'v1.11.0'
-    otpVersion = '22.3.4.2'
-    expected = 'v1.11.0-otp-22'
-    got = await setupBeam.getElixirVersion(spec, otpVersion)
-    assert.deepStrictEqual(got, expected)
-    simulateInput('version-type', before)
+      before = simulateInput('version-type', 'strict')
+      spec = 'main'
+      otpVersion = '25.2'
+      expected = 'main-otp-25'
+      await setupBeam.installOTP(otpVersion)
+      got = await setupBeam.getElixirVersion(spec, otpVersion)
+      assert.deepStrictEqual(got, expected)
+      simulateInput('version-type', before)
+    })
+  }
 
-    before = simulateInput('version-type', 'strict')
-    spec = 'main'
-    otpVersion = '23.1'
-    expected = 'main-otp-23'
-    got = await setupBeam.getElixirVersion(spec, otpVersion)
-    assert.deepStrictEqual(got, expected)
-    simulateInput('version-type', before)
-  })
-
-  simulateInput('hexpm-mirrors', hexMirrors, { multiline: true })
+  process.env.RUNNER_ARCH = previousRunnerArch
 })
 
 describe('.getOTPVersion(_) - Gleam', () => {

--- a/test/setup-beam.test.js
+++ b/test/setup-beam.test.js
@@ -936,18 +936,16 @@ describe('version file', () => {
   const otpVersion = unsimulateInput('otp-version')
   const elixirVersion = unsimulateInput('elixir-version')
   const gleamVersion = unsimulateInput('gleam-version')
-  const rebar3Version = unsimulateInput('rebar3-version')
 
   it('is parsed correctly', async () => {
     const erlang = '27'
     const elixir = '1.17.0'
     const gleam = '0.23.0'
-    const rebar3 = '3.24.0'
     const toolVersions = `# a comment
 erlang   ref:v${erlang}# comment, no space, and ref:v
 elixir ref:${elixir}  # comment, with space and ref:
  not-gleam 0.23 # not picked up
-gleam ${gleam} \nrebar ${rebar3}`
+gleam ${gleam} \n`
     const filename = 'test/.tool-versions'
     fs.writeFileSync(filename, toolVersions)
     process.env.GITHUB_WORKSPACE = ''
@@ -972,15 +970,11 @@ gleam ${gleam} \nrebar ${rebar3}`
     assert.ok(async () => {
       await setupBeam.install('gleam', { toolVersion: gleam })
     })
-    assert.ok(async () => {
-      await setupBeam.install('rebar3', { toolVersion: rebar3 })
-    })
   })
 
   simulateInput('otp-version', otpVersion)
   simulateInput('elixir-version', elixirVersion)
   simulateInput('gleam-version', gleamVersion)
-  simulateInput('rebar3-version', rebar3Version)
 })
 
 describe('.get(_)', () => {


### PR DESCRIPTION
# Description

We keep the previous constraint of "user-defined version as 1.19-otp-28" winning over the OTP input, but we now use the `otpVersion` from the installed OTP instead of the user input, which also simplifies code around regular expressions.

- [x] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)

## What changes

* we add `process.env.NODE_ENV` to allow bypassing the initial action run during tests
* instead of calculating `otpVersionMajor` based on input and regex, we make an actual system call (sync) to determine it and use it
  * the "bypass if forced" mechanism that was in place stays in place
* per @wojtekmach's input, the Elixir version matching mechanism was changes to start from the detected OTP versions and iterate down until it finds a corresponding Elixir version (this "avoids" OTP `master` / Elixir `main` from becoming Elixir `main` and not `main-otp-29`, for example, when that one's out
* I reduced duplicate (in nature) test for the Elixir version checks

... everything else remains the same

## Version matching examples (from the tests)

- OTP `<26` / Elixir `<1.17` results in Elixir `v1.16.3-otp-25`
- OTP `master` / Elixir `> 0` results in Elixir `v1.19-otp-28`
- OTP `master` / Elixir `main` results in Elixir `main-otp-28`
- OTP `OTP-27` / Elixir `1.18.x` results in Elixir `v1.18.4-otp-27`
- OTP `OTP-26` / Elixir `v1.15.0-rc.2` results in Elixir `v1.15.0-rc.2-otp-26`
- OTP `25.2` / Elixir `main` results in Elixir `main-otp-25`