### PR TITLE
Improve output (around "Requested ... version") when we know input

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -26066,11 +26066,21 @@ async function getOTPVersion(otpSpec0, osVersion) {
 }
 
 function requestedVersionFor(tool, version, originListing, mirrors) {
-  return (
-    `Requested ${tool} version (${version}) not found in version list, ` +
-    `at ${originListing}${mirrors ? `, with mirrors ${mirrors}` : ''}; ` +
-    "should you be using option 'version-type': 'strict'?"
-  )
+  const isStrictVersion = isStrictVersion()
+
+  let versionType = 'loose'
+  if (isStrictVersion) {
+    versionType = 'strict'
+  }
+
+  let ret =
+    `Requested ${versionType} ${tool} version (${version}) not found in version list, ` +
+    `at ${originListing}${mirrors ? `, with mirrors ${mirrors}` : ''}.`
+  if (!isStrictVersion) {
+    ret = `${ret} Should you be using option 'version-type': 'strict'?`
+  }
+
+  return ret
 }
 
 const knownBranches = ['main', 'master', 'maint']

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -191,11 +191,21 @@ async function getOTPVersion(otpSpec0, osVersion) {
 }
 
 function requestedVersionFor(tool, version, originListing, mirrors) {
-  return (
-    `Requested ${tool} version (${version}) not found in version list, ` +
-    `at ${originListing}${mirrors ? `, with mirrors ${mirrors}` : ''}; ` +
-    "should you be using option 'version-type': 'strict'?"
-  )
+  const isStrictVersion = isStrictVersion()
+
+  let versionType = 'loose'
+  if (isStrictVersion) {
+    versionType = 'strict'
+  }
+
+  let ret =
+    `Requested ${versionType} ${tool} version (${version}) not found in version list, ` +
+    `at ${originListing}${mirrors ? `, with mirrors ${mirrors}` : ''}.`
+  if (!isStrictVersion) {
+    ret = `${ret} Should you be using option 'version-type': 'strict'?`
+  }
+
+  return ret
 }
 
 const knownBranches = ['main', 'master', 'maint']


### PR DESCRIPTION
# Description

We don't propose (or even question) misleading `strict` if we know it's already strict.
We add the version type to the output message so the consumer has more information to act on.

- [x] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)
