### PR TITLE
Compatibility matrix strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ and Erlang/OTP.
 
 ### Compatibility between Erlang/OTP and rebar3
 
-Check [version compatibility](https://github.com/erlang/rebar3?tab=readme-ov-file#compatibility-between-rebar3-and-erlangotp) in `erlang/rebar3`.
+Check [version compatibility](https://github.com/erlang/rebar3?tab=readme-ov-file#compatibility-between-rebar3-and-erlangotp)
+in `erlang/rebar3`.
 
 ### Self-hosted runners
 
@@ -297,7 +298,8 @@ jobs:
 
 ### Compatibility
 
-Matrix-style testing can be executed using pinned, compatible dependency versions by configuring the test matrix accordingly:
+To execute matrix testing with specific dependency versions, configure the environment matrix to
+use pinned, compatible releases:
 
 ```yaml
   test:


### PR DESCRIPTION
# Description

Re-opened #313 with review fixes

Example on how one can maintain a compatibility matrix.
Note I've not tested keeping the os-version in the strategy itself, but according to the github documentation it works for the runs-on argument as well.

I'm currently running otp-rebar pinning for another project for OTP22-OTP27 versions below.
And I ran a similar thing (though not with erlef/setup-beam) previously for the same project for OTP17-21.

I'll add the os-version to my project for testing, but I wanted early feedback on your thoughts.

- [X] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)
