### PR TITLE
fix: canonicalize Windows ImageOS variant suffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ jobs:
         ...
 ```
 
+For Windows images, suffix variants are canonicalized to the base `winNN` value.
+For example, `win25-vs2026` is treated as `win25`.
+This handles runner label-to-image issues discussed in
+[`actions/runner-images#14004`](https://github.com/actions/runner-images/issues/14004).
+
 ### Outputs
 
 The action provides the following outputs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -55353,6 +55353,14 @@ function getRunnerOSArchitecture() {
   )
 }
 
+/**
+ * Strip Windows runner-image variant suffixes (e.g. "win25-vs2026" → "win25").
+ * Deliberately only targets Windows; see actions/runner-images#14004.
+ */
+function canonicalizeImageOS(imageOS) {
+  return imageOS.replace(/^(win\d{2})-.+$/, '$1')
+}
+
 function getRunnerOSVersion() {
   // List from https://github.com/actions/runner-images?tab=readme-ov-file#available-images
   const ImageOSToContainer = {
@@ -55370,10 +55378,12 @@ function getRunnerOSVersion() {
     ubuntu18: 'ubuntu-18.04',
     ubuntu20: 'ubuntu-20.04',
   }
-  const containerFromEnvImageOS = ImageOSToContainer[process.env.ImageOS]
+  const imageOS = process.env.ImageOS || ''
+  const canonicalImageOS = canonicalizeImageOS(imageOS)
+  const containerFromEnvImageOS = ImageOSToContainer[canonicalImageOS]
   if (!containerFromEnvImageOS) {
     const deprecatedContainerFromEnvImageOS =
-      deprecatedImageOSToContainer[process.env.ImageOS]
+      deprecatedImageOSToContainer[canonicalImageOS]
     if (deprecatedContainerFromEnvImageOS) {
       warning(
         `You are using deprecated ImageOS ${deprecatedContainerFromEnvImageOS}. ` +
@@ -55385,7 +55395,7 @@ function getRunnerOSVersion() {
     } else {
       throw new Error(
         "Tried to map a target OS from env. variable 'ImageOS' (got " +
-          `${process.env.ImageOS}` +
+          `${imageOS}` +
           "), but failed. If you're using a " +
           "self-hosted runner, you should set 'env': 'ImageOS': ... to one of the following: " +
           "['" +
@@ -55988,6 +55998,7 @@ function debugLoggingEnabled() {
 }
 
 /* harmony default export */ const setup_beam = ({
+  canonicalizeImageOS,
   get,
   getElixirVersion,
   getGleamVersion,

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -659,6 +659,14 @@ function getRunnerOSArchitecture() {
   )
 }
 
+/**
+ * Strip Windows runner-image variant suffixes (e.g. "win25-vs2026" → "win25").
+ * Deliberately only targets Windows; see actions/runner-images#14004.
+ */
+function canonicalizeImageOS(imageOS) {
+  return imageOS.replace(/^(win\d{2})-.+$/, '$1')
+}
+
 function getRunnerOSVersion() {
   // List from https://github.com/actions/runner-images?tab=readme-ov-file#available-images
   const ImageOSToContainer = {
@@ -676,10 +684,12 @@ function getRunnerOSVersion() {
     ubuntu18: 'ubuntu-18.04',
     ubuntu20: 'ubuntu-20.04',
   }
-  const containerFromEnvImageOS = ImageOSToContainer[process.env.ImageOS]
+  const imageOS = process.env.ImageOS || ''
+  const canonicalImageOS = canonicalizeImageOS(imageOS)
+  const containerFromEnvImageOS = ImageOSToContainer[canonicalImageOS]
   if (!containerFromEnvImageOS) {
     const deprecatedContainerFromEnvImageOS =
-      deprecatedImageOSToContainer[process.env.ImageOS]
+      deprecatedImageOSToContainer[canonicalImageOS]
     if (deprecatedContainerFromEnvImageOS) {
       core.warning(
         `You are using deprecated ImageOS ${deprecatedContainerFromEnvImageOS}. ` +
@@ -691,7 +701,7 @@ function getRunnerOSVersion() {
     } else {
       throw new Error(
         "Tried to map a target OS from env. variable 'ImageOS' (got " +
-          `${process.env.ImageOS}` +
+          `${imageOS}` +
           "), but failed. If you're using a " +
           "self-hosted runner, you should set 'env': 'ImageOS': ... to one of the following: " +
           "['" +
@@ -1294,6 +1304,7 @@ function debugLoggingEnabled() {
 }
 
 export default {
+  canonicalizeImageOS,
   get,
   getElixirVersion,
   getGleamVersion,

--- a/test/setup-beam.test.js
+++ b/test/setup-beam.test.js
@@ -1102,6 +1102,28 @@ describe('.get(_)', () => {
   })
 })
 
+describe('.canonicalizeImageOS()', () => {
+  it('passes through a standard ImageOS value unchanged', () => {
+    assert.equal(setupBeam.canonicalizeImageOS('ubuntu24'), 'ubuntu24')
+    assert.equal(setupBeam.canonicalizeImageOS('macos15'), 'macos15')
+    assert.equal(setupBeam.canonicalizeImageOS('win25'), 'win25')
+  })
+
+  it('strips Windows runner-image variant suffixes', () => {
+    assert.equal(setupBeam.canonicalizeImageOS('win25-vs2026'), 'win25')
+    assert.equal(setupBeam.canonicalizeImageOS('win22-vs2022'), 'win22')
+  })
+
+  it('does not alter non-Windows suffixed values', () => {
+    assert.equal(setupBeam.canonicalizeImageOS('macos15'), 'macos15')
+    assert.equal(setupBeam.canonicalizeImageOS('ubuntu24'), 'ubuntu24')
+  })
+
+  it('handles empty string', () => {
+    assert.equal(setupBeam.canonicalizeImageOS(''), '')
+  })
+})
+
 describe("Elixir Mix matcher's", () => {
   it('errors are properly matched', async () => {
     const [matcher] = problemMatcher.find(


### PR DESCRIPTION
# Description

Strip runner-image variant suffixes from Windows ImageOS values (e.g., "win25-vs2026" → "win25") to prevent label-to-image transitions from breaking the OS version lookup.

Ref: https://github.com/actions/runner-images/issues/14004

- [x] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)