### PR TITLE
Add tests for arm64 Linux runner OS detection

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -39137,6 +39137,7 @@ function debugLoggingEnabled() {
   getGleamVersion,
   getOTPVersion,
   getRebar3Version,
+  getRunnerOSVersion,
   getVersionFromSpec,
   githubAMDRunnerArchs,
   githubARMRunnerArchs,

--- a/src/setup-beam.js
+++ b/src/setup-beam.js
@@ -1306,6 +1306,7 @@ export default {
   getGleamVersion,
   getOTPVersion,
   getRebar3Version,
+  getRunnerOSVersion,
   getVersionFromSpec,
   githubAMDRunnerArchs,
   githubARMRunnerArchs,

--- a/test/setup-beam.test.js
+++ b/test/setup-beam.test.js
@@ -587,6 +587,44 @@ describe('OTP arch-specific install', () => {
   })
 })
 
+describe('.getRunnerOSVersion(_)', () => {
+  it('maps x86 ImageOS values to their container', async () => {
+    const previousImageOS = process.env.ImageOS
+
+    process.env.ImageOS = 'ubuntu22'
+    assert.strictEqual(setupBeam.getRunnerOSVersion(), 'ubuntu-22.04')
+
+    process.env.ImageOS = 'ubuntu24'
+    assert.strictEqual(setupBeam.getRunnerOSVersion(), 'ubuntu-24.04')
+
+    process.env.ImageOS = previousImageOS
+  })
+
+  it('maps arm64 ImageOS variants to the same container as x86', async () => {
+    const previousImageOS = process.env.ImageOS
+
+    process.env.ImageOS = 'ubuntu22-arm64'
+    assert.strictEqual(setupBeam.getRunnerOSVersion(), 'ubuntu-22.04')
+
+    process.env.ImageOS = 'ubuntu24-arm64'
+    assert.strictEqual(setupBeam.getRunnerOSVersion(), 'ubuntu-24.04')
+
+    process.env.ImageOS = previousImageOS
+  })
+
+  it('throws for genuinely unknown ImageOS values', async () => {
+    const previousImageOS = process.env.ImageOS
+
+    process.env.ImageOS = 'plan9'
+    assert.throws(
+      () => setupBeam.getRunnerOSVersion(),
+      /Tried to map a target OS/,
+    )
+
+    process.env.ImageOS = previousImageOS
+  })
+})
+
 describe('.getOTPVersion(_) - Elixir', () => {
   let got
   let expected


### PR DESCRIPTION
actions/runner-images#14113 gave arm64 Ubuntu images distinct ImageOS values (e.g. ubuntu24-arm64 instead of ubuntu24), which don't appear in the `ImageOSToContainer` table, causing setup to fail on ubuntu-*-arm runners. This has been fixed on main, but this PR adds tests to catch any regression.

- [x] I have read and understood the [contributing guidelines](/erlef/setup-beam/blob/main/CONTRIBUTING.md)
